### PR TITLE
Add property-based tests for median calculation

### DIFF
--- a/contracts/price-oracle/Cargo.toml
+++ b/contracts/price-oracle/Cargo.toml
@@ -13,3 +13,9 @@ soroban-sdk = { version = "26" }
 
 [dev-dependencies]
 soroban-sdk = { version = "26", features = ["testutils"] }
+proptest = { version = "1.5.0", default-features = false, features = ["std"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
+
+[[bench]]
+name = "oracle_benchmarks"
+harness = false

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -10,6 +10,9 @@ mod sources;
 mod storage;
 mod types;
 
+#[cfg(test)]
+mod prop_tests;
+
 pub use types::{
     AggregatePrice, Asset, DataKey, ErrorCode, OracleSources, PriceData, PriceEntry,
     PriceHistoryEntry,

--- a/contracts/price-oracle/src/prop_tests.rs
+++ b/contracts/price-oracle/src/prop_tests.rs
@@ -1,0 +1,77 @@
+#![cfg(test)]
+
+use proptest::prelude::*;
+use soroban_sdk::Env;
+
+use crate::storage::compute_median;
+
+fn to_sdk_vec(env: &Env, v: &[i64]) -> soroban_sdk::Vec<i128> {
+    let mut sv = soroban_sdk::Vec::new(env);
+    for &x in v {
+        sv.push_back(x as i128);
+    }
+    sv
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    /// Median of an odd-length sorted list equals the middle element.
+    #[test]
+    fn median_odd_is_middle(mut vals in proptest::collection::vec(any::<i64>(), 1..=49usize).prop_filter("odd length", |v| v.len() % 2 == 1)) {
+        let env = Env::default();
+        vals.sort();
+        let mid = vals[vals.len() / 2] as i128;
+        let sv = to_sdk_vec(&env, &vals);
+        prop_assert_eq!(compute_median(&sv), mid);
+    }
+
+    /// Median of an even-length sorted list equals the average of the two middle elements.
+    #[test]
+    fn median_even_is_avg_of_middles(mut vals in proptest::collection::vec(any::<i64>(), 2..=50usize).prop_filter("even length", |v| v.len() % 2 == 0)) {
+        let env = Env::default();
+        vals.sort();
+        let mid = vals.len() / 2;
+        let a = vals[mid - 1] as i128;
+        let b = vals[mid] as i128;
+        let expected = a + (b - a) / 2;
+        let sv = to_sdk_vec(&env, &vals);
+        prop_assert_eq!(compute_median(&sv), expected);
+    }
+
+    /// Median is always between min and max.
+    #[test]
+    fn median_between_min_and_max(vals in proptest::collection::vec(any::<i64>(), 1..=50usize)) {
+        let env = Env::default();
+        let min = *vals.iter().min().unwrap() as i128;
+        let max = *vals.iter().max().unwrap() as i128;
+        let sv = to_sdk_vec(&env, &vals);
+        let m = compute_median(&sv);
+        prop_assert!(m >= min && m <= max);
+    }
+
+    /// Adding the median value to the set does not change the median.
+    #[test]
+    fn median_stable_when_median_added(vals in proptest::collection::vec(any::<i64>(), 1..=49usize)) {
+        let env = Env::default();
+        let sv = to_sdk_vec(&env, &vals);
+        let m = compute_median(&sv);
+        // m fits in i64 range since inputs are i64-based
+        let mut extended = vals.clone();
+        extended.push(m as i64);
+        let sv2 = to_sdk_vec(&env, &extended);
+        prop_assert_eq!(compute_median(&sv2), m);
+    }
+
+    /// Median is invariant under permutation (reverse as a proxy).
+    #[test]
+    fn median_invariant_under_permutation(vals in proptest::collection::vec(any::<i64>(), 1..=50usize)) {
+        let env = Env::default();
+        let sv = to_sdk_vec(&env, &vals);
+        let m = compute_median(&sv);
+        let mut rev = vals.clone();
+        rev.reverse();
+        let sv_rev = to_sdk_vec(&env, &rev);
+        prop_assert_eq!(compute_median(&sv_rev), m);
+    }
+}


### PR DESCRIPTION
closes #27 
closes #28 
closes #29 
closes #30 

- Added proptest dependency to dev-dependencies
- Implemented comprehensive property tests in prop_tests.rs:
  - median_odd_is_middle: Tests odd-length lists
  - median_even_is_avg_of_middles: Tests even-length lists
  - median_between_min_and_max: Verifies median bounds
  - median_stable_when_median_added: Tests median invariance
  - median_invariant_under_permutation: Tests permutation invariance
- Updated Cargo.toml to include criterion benchmarking tool

## Description

<!-- What does this PR do? Why is it needed? -->

## Related issue

<!-- Link to the GitHub issue this resolves, e.g., Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / performance
- [ ] Documentation
- [ ] CI / tooling

## Testing

- [ ] All existing tests pass (`cargo test -p price-oracle --lib`)
- [ ] New tests added for the change
- [ ] Clippy is clean (`cargo clippy -- -D warnings`)
- [ ] Formatting is clean (`cargo fmt -- --check`)

## Checklist

- [ ] My code follows the existing code style and patterns
- [ ] I have updated the README if needed
- [ ] Events are emitted for state-changing operations
- [ ] Authorization checks are in place for admin-only functions
