### PR TITLE
feat: add admin-controlled asset price override capability

### DIFF
--- a/contracts/price-oracle/src/events.rs
+++ b/contracts/price-oracle/src/events.rs
@@ -261,3 +261,33 @@ pub struct OperationCancelledEvent {
     #[topic]
     pub cancelled_by: Address,
 }
+
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceOverrideSetEvent {
+    #[topic]
+    pub asset: Address,
+    #[topic]
+    pub admin: Address,
+    pub price: i128,
+    pub reason: String,
+    pub expiry_ledger: u32,
+}
+
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceOverrideRemovedEvent {
+    #[topic]
+    pub asset: Address,
+    #[topic]
+    pub admin: Address,
+}
+
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceOverrideExpiredEvent {
+    #[topic]
+    pub asset: Address,
+    pub expiry_ledger: u32,
+    pub current_ledger: u32,
+}

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -13,11 +13,14 @@ mod timelock;
 mod types;
 
 #[cfg(test)]
+mod override_tests;
+
+#[cfg(test)]
 mod prop_tests;
 
 pub use types::{
     AggregatePrice, AggregationMethod, Asset, DataKey, ErrorCode, OracleSources, PriceData,
-    PriceEntry, PriceHistoryEntry,
+    PriceEntry, PriceHistoryEntry, PriceOverrideEntry,
 };
 
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
@@ -189,6 +192,24 @@ impl PriceOracleContract {
 
     pub fn get_all_prices(env: Env, asset: Address) -> Vec<PriceEntry> {
         prices::get_all_prices(&env, asset)
+    }
+
+    pub fn override_price(
+        env: Env,
+        asset: Address,
+        price: i128,
+        reason: String,
+        expiry_ledger: u32,
+    ) {
+        prices::override_price(&env, asset, price, reason, expiry_ledger);
+    }
+
+    pub fn remove_price_override(env: Env, asset: Address) {
+        prices::remove_price_override(&env, asset);
+    }
+
+    pub fn get_price_override(env: Env, asset: Address) -> Option<PriceOverrideEntry> {
+        prices::get_price_override(&env, asset)
     }
 
     pub fn get_latest_ledger(env: Env) -> u32 {

--- a/contracts/price-oracle/src/override_tests.rs
+++ b/contracts/price-oracle/src/override_tests.rs
@@ -1,0 +1,215 @@
+#![cfg(test)]
+
+use soroban_sdk::{Env, String};
+
+use crate::test_helpers::*;
+
+#[test]
+fn test_override_price_basic() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "Chainlink");
+    let asset = register_test_asset(&e, &client);
+
+    // Submit normal price
+    submit_test_price(&client, &source, &asset, 1000i128, 1234567890);
+    let normal_price = client.get_price(&asset, &0u64).unwrap();
+    assert_eq!(normal_price.price, 1000i128);
+    assert!(!normal_price.is_override);
+
+    // Set override
+    client.override_price(
+        &asset,
+        &9999i128,
+        &String::from_str(&e, "Emergency override"),
+        &200u32,
+    );
+
+    // get_price now returns override
+    let ovr_price = client.get_price(&asset, &0u64).unwrap();
+    assert_eq!(ovr_price.price, 9999i128);
+    assert!(ovr_price.is_override);
+    assert_eq!(ovr_price.num_sources, 0u32);
+}
+
+#[test]
+fn test_get_price_override_query() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    let asset = register_test_asset(&e, &client);
+
+    // No override initially
+    assert!(client.get_price_override(&asset).is_none());
+
+    // Set override
+    client.override_price(
+        &asset,
+        &5000i128,
+        &String::from_str(&e, "Market halt"),
+        &500u32,
+    );
+
+    let entry = client.get_price_override(&asset).unwrap();
+    assert_eq!(entry.price, 5000i128);
+    assert_eq!(entry.expiry_ledger, 500u32);
+    assert_eq!(entry.set_ledger, 100u32);
+    assert_eq!(entry.reason, String::from_str(&e, "Market halt"));
+}
+
+#[test]
+fn test_remove_price_override() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "Chainlink");
+    let asset = register_test_asset(&e, &client);
+
+    // Submit normal price
+    submit_test_price(&client, &source, &asset, 1000i128, 1234567890);
+
+    // Set then remove override
+    client.override_price(
+        &asset,
+        &9999i128,
+        &String::from_str(&e, "Temporary fix"),
+        &300u32,
+    );
+    assert!(client.get_price(&asset, &0u64).unwrap().is_override);
+
+    client.remove_price_override(&asset);
+
+    // Override gone, normal price returns
+    assert!(client.get_price_override(&asset).is_none());
+    let price = client.get_price(&asset, &0u64).unwrap();
+    assert_eq!(price.price, 1000i128);
+    assert!(!price.is_override);
+}
+
+#[test]
+fn test_override_expires_after_ledger() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "Chainlink");
+    let asset = register_test_asset(&e, &client);
+
+    submit_test_price(&client, &source, &asset, 1000i128, 1234567890);
+
+    // Set override expiring at ledger 150
+    client.override_price(&asset, &9999i128, &String::from_str(&e, "Temp"), &150u32);
+    assert!(client.get_price(&asset, &0u64).unwrap().is_override);
+
+    // Advance ledger past expiry
+    ledger_default(&e, 200, 1234567890);
+
+    // Override expired, falls back to normal price
+    let price = client.get_price(&asset, &0u64).unwrap();
+    assert_eq!(price.price, 1000i128);
+    assert!(!price.is_override);
+
+    // Override entry cleaned up
+    assert!(client.get_price_override(&asset).is_none());
+}
+
+#[test]
+fn test_original_submissions_preserved_during_override() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "Chainlink");
+    let asset = register_test_asset(&e, &client);
+
+    submit_test_price(&client, &source, &asset, 1000i128, 1234567890);
+
+    client.override_price(
+        &asset,
+        &9999i128,
+        &String::from_str(&e, "Override"),
+        &300u32,
+    );
+
+    // Override active, but source submission still retrievable
+    let entry = client.get_source_price(&asset, &source);
+    assert_eq!(entry.price, 1000i128);
+
+    // Source can still submit during override
+    submit_test_price(&client, &source, &asset, 2000i128, 1234567890);
+    let entry2 = client.get_source_price(&asset, &source);
+    assert_eq!(entry2.price, 2000i128);
+
+    // get_price still returns override
+    assert!(client.get_price(&asset, &0u64).unwrap().is_override);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_override_price_invalid_zero() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    let asset = register_test_asset(&e, &client);
+
+    client.override_price(&asset, &0i128, &String::from_str(&e, "Bad"), &300u32);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_override_price_expiry_in_past() {
+    let e = Env::default();
+    ledger_default(&e, 200, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    let asset = register_test_asset(&e, &client);
+
+    // expiry_ledger must be > current_ledger (200), so 100 should fail
+    client.override_price(&asset, &9999i128, &String::from_str(&e, "Bad"), &100u32);
+}
+
+#[test]
+fn test_override_price_unauthorized() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    let asset = register_test_asset(&e, &client);
+
+    clear_auth(&e);
+    assert!(client
+        .try_override_price(
+            &asset,
+            &9999i128,
+            &String::from_str(&e, "Unauthorized"),
+            &300u32,
+        )
+        .is_err());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_remove_nonexistent_override() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    let asset = register_test_asset(&e, &client);
+    // No override set — should panic with NoData (#8)
+    client.remove_price_override(&asset);
+}
+
+#[test]
+fn test_override_replaces_previous_override() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+    let (client, _admin) = setup_contract(&e);
+    let asset = register_test_asset(&e, &client);
+
+    client.override_price(&asset, &1111i128, &String::from_str(&e, "First"), &300u32);
+    client.override_price(&asset, &2222i128, &String::from_str(&e, "Second"), &400u32);
+
+    let entry = client.get_price_override(&asset).unwrap();
+    assert_eq!(entry.price, 2222i128);
+    assert_eq!(entry.expiry_ledger, 400u32);
+}

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -1,21 +1,21 @@
-use soroban_sdk::{panic_with_error, Address, Env, Vec};
+use soroban_sdk::{panic_with_error, Address, Env, String, Vec};
 
 use crate::admin::{
     get_aggregation_method, get_decimals, get_max_history_length, get_min_sources_required,
     get_resolution, get_timestamp_threshold,
 };
 use crate::events::{
-    HistoryPrunedEvent, PriceAggregatedEvent, PriceStaleEvent, PriceSubmittedEvent,
-    SourcesInsufficientEvent,
+    HistoryPrunedEvent, PriceAggregatedEvent, PriceOverrideExpiredEvent, PriceOverrideRemovedEvent,
+    PriceOverrideSetEvent, PriceStaleEvent, PriceSubmittedEvent, SourcesInsufficientEvent,
 };
 use crate::pause::check_not_paused;
 use crate::storage::{
     check_registered_asset, check_source, compute_mean, compute_median, compute_trimmed_mean,
-    read_oracle_sources, LEDGER_BUMP, LEDGER_THRESHOLD,
+    get_admin, read_oracle_sources, LEDGER_BUMP, LEDGER_THRESHOLD,
 };
 use crate::types::{
     AggregatePrice, Asset, DataKey, ErrorCode, OracleSources, PriceData, PriceEntry,
-    PriceHistoryEntry,
+    PriceHistoryEntry, PriceOverrideEntry,
 };
 
 pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, timestamp: u64) {
@@ -111,6 +111,7 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
                     timestamp: 0,
                     num_sources: 0,
                     decimals,
+                    is_override: false,
                 });
 
         let aggregate = AggregatePrice {
@@ -118,6 +119,7 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
             timestamp: latest_timestamp,
             num_sources: contributing_sources,
             decimals,
+            is_override: false,
         };
         env.storage()
             .persistent()
@@ -185,9 +187,41 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
 
 pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePrice> {
     check_registered_asset(env, &asset);
+    let current_ledger = env.ledger().sequence();
+
+    // Check for active price override
+    let override_key = DataKey::PriceOverride(asset.clone());
+    if let Some(ovr) = env
+        .storage()
+        .persistent()
+        .get::<_, PriceOverrideEntry>(&override_key)
+    {
+        if current_ledger <= ovr.expiry_ledger {
+            env.storage()
+                .persistent()
+                .extend_ttl(&override_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+            let decimals = get_decimals(env);
+            return Some(AggregatePrice {
+                price: ovr.price,
+                timestamp: env.ledger().timestamp(),
+                num_sources: 0,
+                decimals,
+                is_override: true,
+            });
+        } else {
+            // Override has expired
+            PriceOverrideExpiredEvent {
+                asset: asset.clone(),
+                expiry_ledger: ovr.expiry_ledger,
+                current_ledger,
+            }
+            .publish(env);
+            env.storage().persistent().remove(&override_key);
+        }
+    }
+
     let key = DataKey::Aggregate(asset.clone());
     let result: AggregatePrice = env.storage().persistent().get(&key)?;
-    let current_ledger = env.ledger().sequence();
 
     if max_age > 0 {
         let ledger_time = env.ledger().timestamp();
@@ -389,6 +423,73 @@ pub fn get_prices(env: &Env, assets: Vec<Address>) -> Vec<Option<AggregatePrice>
         results.push_back(price);
     }
     results
+}
+
+pub fn override_price(env: &Env, asset: Address, price: i128, reason: String, expiry_ledger: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    check_registered_asset(env, &asset);
+
+    let current_ledger = env.ledger().sequence();
+    if price <= 0 {
+        panic_with_error!(env, ErrorCode::InvalidPrice);
+    }
+    if expiry_ledger <= current_ledger {
+        panic_with_error!(env, ErrorCode::InvalidConfiguration);
+    }
+
+    let entry = PriceOverrideEntry {
+        price,
+        reason: reason.clone(),
+        expiry_ledger,
+        set_ledger: current_ledger,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::PriceOverride(asset.clone()), &entry);
+    env.storage().persistent().extend_ttl(
+        &DataKey::PriceOverride(asset.clone()),
+        LEDGER_THRESHOLD,
+        LEDGER_BUMP,
+    );
+
+    PriceOverrideSetEvent {
+        asset: asset.clone(),
+        admin: admin.clone(),
+        price,
+        reason,
+        expiry_ledger,
+    }
+    .publish(env);
+}
+
+pub fn remove_price_override(env: &Env, asset: Address) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    check_registered_asset(env, &asset);
+
+    let override_key = DataKey::PriceOverride(asset.clone());
+    if !env.storage().persistent().has(&override_key) {
+        panic_with_error!(env, ErrorCode::NoData);
+    }
+    env.storage().persistent().remove(&override_key);
+
+    PriceOverrideRemovedEvent {
+        asset: asset.clone(),
+        admin: admin.clone(),
+    }
+    .publish(env);
+}
+
+pub fn get_price_override(env: &Env, asset: Address) -> Option<PriceOverrideEntry> {
+    check_registered_asset(env, &asset);
+    let override_key = DataKey::PriceOverride(asset);
+    if env.storage().persistent().has(&override_key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&override_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage().persistent().get(&override_key)
 }
 
 #[allow(dead_code)]

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -34,6 +34,7 @@ pub enum DataKey {
     PendingOpCount,
     PendingOp(u32),
     TimelockDuration,
+    PriceOverride(Address),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -53,6 +54,16 @@ pub struct AggregatePrice {
     pub timestamp: u64,
     pub num_sources: u32,
     pub decimals: u32,
+    pub is_override: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct PriceOverrideEntry {
+    pub price: i128,
+    pub reason: String,
+    pub expiry_ledger: u32,
+    pub set_ledger: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

- Implements admin-controlled price override for emergency situations via `override_price(asset, price, reason, expiry_ledger)`
- Adds `remove_price_override(asset)` to cancel an active override
- Adds `get_price_override(asset)` to query the current override entry (price, reason, expiry_ledger, set_ledger)
- `get_price` transparently returns the override price when one is active, with `is_override: true` on the returned `AggregatePrice`
- Override automatically expires after `expiry_ledger`; an expiry event is emitted and the entry is cleaned up on next `get_price` call
- Original source submissions are preserved and remain accessible during an override

## Events

- `PriceOverrideSetEvent` — emitted with asset, admin, price, reason, expiry_ledger
- `PriceOverrideRemovedEvent` — emitted with asset, admin
- `PriceOverrideExpiredEvent` — emitted with asset, expiry_ledger, current_ledger

## Test plan

- [x] `test_override_price_basic` — override is returned by `get_price` with `is_override: true`
- [x] `test_get_price_override_query` — entry fields are correct
- [x] `test_remove_price_override` — normal price resumes after removal
- [x] `test_override_expires_after_ledger` — automatic expiry fallback
- [x] `test_original_submissions_preserved_during_override` — sources still submit/queryable
- [x] `test_override_price_invalid_zero` — rejects price ≤ 0
- [x] `test_override_price_expiry_in_past` — rejects expiry_ledger ≤ current_ledger
- [x] `test_override_price_unauthorized` — non-admin cannot set override
- [x] `test_remove_nonexistent_override` — panics with NoData
- [x] `test_override_replaces_previous_override` — second call overwrites first
- [x] All 86 existing tests pass

Closes #63