### PR TITLE
fix: pin Rust toolchain version and add pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+cargo fmt --manifest-path contracts/price-oracle/Cargo.toml -- --check
+cargo clippy -p price-oracle -- -D warnings

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.90.0"
 targets = ["wasm32v1-none"]


### PR DESCRIPTION
Closes #35
Closes #36

---

## Issue #36 — Add rust-toolchain.toml with pinned version

### Problem
The existing rust-toolchain.toml only specified channel = "stable" without pinning an exact version. This means different developers and CI runs could silently use different Rust versions, leading to non-reproducible builds, divergent clippy lint results, and subtle behaviour differences across environments.

### Solution
Updated rust-toolchain.toml to pin channel = "1.90.0" (the current stable toolchain in use on this machine). The wasm32v1-none target entry is preserved so the WASM build target is still automatically provisioned by rustup on any fresh checkout.

### Files changed
- rust-toolchain.toml: changed channel from "stable" to "1.90.0"

---

## Issue #35 — Add pre-commit hook for formatting and linting

### Problem
There was no pre-commit hook in the repository. Developers could commit code that fails cargo fmt or cargo clippy checks, only discovering the issue when CI ran — causing noisy CI failures and back-and-forth fix commits.

### Solution
Adde
- [ ] New tests added for the change
- [ ] Clippy is clean (`cargo clippy -- -D warnings`)
- [ ] Formatting is clean (`cargo fmt -- --check`)

## Checklist

- [ ] My code follows the existing code style and patterns
- [ ] I have updated the README if needed
- [ ] Events are emitted for state-changing operations
- [ ] Authorization checks are in place for admin-only functions
