### PR TITLE
feat: deployment verification script and monitoring dashboard

### DIFF
--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -1,0 +1,107 @@
+# Monitoring Dashboard — Stellar Unified Price Oracle
+
+This directory contains a [Grafana](https://grafana.com/) dashboard template for monitoring the on-chain activity of the price oracle contract.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `grafana-dashboard.json` | Grafana dashboard definition (import-ready) |
+
+## Dashboard Panels
+
+| Panel Group | What it tracks |
+|-------------|----------------|
+| Contract Configuration | Registered sources count, registered assets count, decimals, min sources required, max history length |
+| Latest Prices per Asset | Aggregated price time-series per asset; per-source price comparison |
+| Source Submission Frequency | Submission rate by source and by asset |
+| Aggregation Events | Price-update event rate; price delta (new − old) per asset |
+| Error Events | Error rate by error code; top errors table; `NotAuthorized` / `InsufficientSources` highlight |
+| Contract Configuration Changes | Count of admin, source, asset, and upgrade change events over 24 h |
+
+## Prerequisites
+
+- **Grafana ≥ 10** (or Grafana Cloud)
+- **Prometheus** (or a compatible backend such as VictoriaMetrics)
+- A **Stellar/Horizon indexer** that exposes oracle contract events as Prometheus metrics
+
+## Metrics Reference
+
+The dashboard expects the following metric names scraped from your indexer:
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `oracle_registered_sources_total` | `contract_id` | Current number of registered oracle sources |
+| `oracle_registered_assets_total` | `contract_id` | Current number of registered assets |
+| `oracle_config_decimals` | `contract_id` | Configured decimal precision |
+| `oracle_config_min_sources_required` | `contract_id` | Minimum sources required for aggregation |
+| `oracle_config_max_history_length` | `contract_id` | Maximum history entries per asset |
+| `oracle_latest_price` | `contract_id`, `asset` | Latest aggregated price |
+| `oracle_source_price` | `contract_id`, `asset`, `source_name` | Latest per-source price |
+| `oracle_price_submissions_total` | `contract_id`, `asset`, `source_name` | Cumulative price submissions |
+| `oracle_price_updated_events_total` | `contract_id`, `asset` | Cumulative aggregation-update events |
+| `oracle_price_delta` | `contract_id`, `asset` | Difference between latest and previous aggregated price |
+| `oracle_errors_total` | `contract_id`, `error_code`, `error_name` | Cumulative contract error events |
+| `oracle_config_change_events_total` | `contract_id`, `event_type` | Cumulative configuration-change events |
+
+### Event types for `oracle_config_change_events_total`
+
+`AdminChanged`, `SourceAdded`, `SourceRemoved`, `AssetRegistered`, `AssetUnregistered`, `ContractUpgraded`, `ContractInitialized`
+
+### Error codes for `oracle_errors_total`
+
+| `error_code` | `error_name` |
+|---|---|
+| 0 | NotAuthorized |
+| 1 | AlreadyInitialized |
+| 2 | AssetNotRegistered |
+| 3 | AssetAlreadyRegistered |
+| 4 | SourceAlreadyExists |
+| 5 | SourceNotFound |
+| 6 | InsufficientSources |
+| 7 | InvalidPrice |
+| 8 | NoData |
+
+## Setup
+
+### 1. Configure your indexer
+
+Point a Horizon event-streaming indexer (e.g., a custom Node.js or Python service) at your contract ID and publish the metrics listed above to a Prometheus `/metrics` endpoint.
+
+The contract emits the following events that map directly to the metrics:
+
+| Contract event | Metrics updated |
+|---|---|
+| `PriceSubmittedEvent` | `oracle_price_submissions_total`, `oracle_source_price`, `oracle_latest_price` |
+| `PriceUpdatedEvent` | `oracle_price_updated_events_total`, `oracle_price_delta`, `oracle_latest_price` |
+| `SourceAddedEvent` / `SourceRemovedEvent` | `oracle_registered_sources_total`, `oracle_config_change_events_total` |
+| `AssetRegisteredEvent` / `AssetUnregisteredEvent` | `oracle_registered_assets_total`, `oracle_config_change_events_total` |
+| `AdminChangedEvent` | `oracle_config_change_events_total` |
+| `ContractUpgradedEvent` | `oracle_config_change_events_total` |
+| Error panics / traps | `oracle_errors_total` |
+
+### 2. Add the Prometheus datasource in Grafana
+
+1. Go to **Connections → Data sources → Add data source**.
+2. Select **Prometheus**.
+3. Set the **URL** to your Prometheus endpoint (e.g., `http://prometheus:9090`).
+4. Click **Save & test**.
+
+### 3. Import the dashboard
+
+1. In Grafana, go to **Dashboards → Import**.
+2. Upload `grafana-dashboard.json` or paste its contents.
+3. Select the **Prometheus** datasource when prompted.
+4. Click **Import**.
+
+### 4. Select your contract
+
+Use the **Contract ID** dropdown at the top of the dashboard to filter all panels to a specific deployed contract.
+
+## Alerting (recommended)
+
+Consider adding Grafana alerts on:
+
+- `oracle_errors_total{error_name="InsufficientSources"}` rate > 0 for > 5 min — sources may be offline
+- `oracle_price_submissions_total` rate = 0 for > 15 min per source — source may be down
+- `oracle_latest_price` unchanged for > staleness window — stale price data

--- a/docs/monitoring/grafana-dashboard.json
+++ b/docs/monitoring/grafana-dashboard.json
@@ -1,0 +1,411 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping your Stellar horizon/indexer metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana",    "id": "grafana",    "name": "Grafana",    "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel",      "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel",      "id": "stat",       "name": "Stat",        "version": "" },
+    { "type": "panel",      "id": "table",      "name": "Table",       "version": "" }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Stellar Unified Price Oracle — on-chain metrics dashboard",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Contract Configuration",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 1 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Registered Sources",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "oracle_registered_sources_total{contract_id=\"$contract_id\"}",
+          "legendFormat": "Sources"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] } },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 4, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Registered Assets",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "oracle_registered_assets_total{contract_id=\"$contract_id\"}",
+          "legendFormat": "Assets"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] } },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 8, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Decimals",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "oracle_config_decimals{contract_id=\"$contract_id\"}",
+          "legendFormat": "Decimals"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "orange", "value": null }] } },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Min Sources Required",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "oracle_config_min_sources_required{contract_id=\"$contract_id\"}",
+          "legendFormat": "Min Sources"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "teal", "value": null }] } },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 16, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Max History Length",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "oracle_config_max_history_length{contract_id=\"$contract_id\"}",
+          "legendFormat": "Max History"
+        }
+      ]
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 },
+      "id": 101,
+      "title": "Latest Prices per Asset",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "id": 10,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "Aggregated Price (by asset)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "oracle_latest_price{contract_id=\"$contract_id\"}",
+          "legendFormat": "{{asset}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 1 }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "id": 11,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "Per-Source Prices (by asset + source)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "oracle_source_price{contract_id=\"$contract_id\"}",
+          "legendFormat": "{{asset}} / {{source_name}}"
+        }
+      ]
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "id": 102,
+      "title": "Source Submission Frequency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2 }, "unit": "ops" },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 14 },
+      "id": 20,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "Price Submissions Rate (per source)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(oracle_price_submissions_total{contract_id=\"$contract_id\"}[5m])",
+          "legendFormat": "{{source_name}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2 }, "unit": "ops" },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 14 },
+      "id": 21,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "Price Submissions Rate (per asset)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(oracle_price_submissions_total{contract_id=\"$contract_id\"}[5m])",
+          "legendFormat": "{{asset}}"
+        }
+      ]
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 },
+      "id": 103,
+      "title": "Aggregation Events",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2 }, "unit": "ops" },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 22 },
+      "id": 30,
+      "title": "Aggregation Updates Rate (by asset)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(oracle_price_updated_events_total{contract_id=\"$contract_id\"}[5m])",
+          "legendFormat": "{{asset}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2 }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 22 },
+      "id": 31,
+      "title": "Price Delta (new − old) per Asset",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "oracle_price_delta{contract_id=\"$contract_id\"}",
+          "legendFormat": "{{asset}}"
+        }
+      ]
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 29 },
+      "id": 104,
+      "title": "Error Events",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2 }, "unit": "ops", "color": { "mode": "palette-classic" } },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 30 },
+      "id": 40,
+      "title": "Contract Error Rate (by error code)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(oracle_errors_total{contract_id=\"$contract_id\"}[5m])",
+          "legendFormat": "{{error_code}} — {{error_name}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "error_code" }, "properties": [{ "id": "custom.width", "value": 100 }] },
+          { "matcher": { "id": "byName", "options": "error_name" }, "properties": [{ "id": "custom.width", "value": 200 }] }
+        ]
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 37 },
+      "id": 41,
+      "title": "Top Errors (last 1 h)",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "topk(10, increase(oracle_errors_total{contract_id=\"$contract_id\"}[1h]))",
+          "legendFormat": "{{error_code}} {{error_name}}",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "renameByName": { "Value": "count", "error_code": "Code", "error_name": "Name" } } }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2 }, "unit": "ops", "color": { "fixedColor": "red", "mode": "fixed" } },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 37 },
+      "id": 42,
+      "title": "Unauthorized / InsufficientSources Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(oracle_errors_total{contract_id=\"$contract_id\", error_code=~\"0|6\"}[5m])",
+          "legendFormat": "{{error_name}}"
+        }
+      ]
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 44 },
+      "id": 105,
+      "title": "Contract Configuration Changes",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 45 },
+      "id": 50,
+      "title": "Config Change Events (admin, sources, assets, upgrades)",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "increase(oracle_config_change_events_total{contract_id=\"$contract_id\"}[24h])",
+          "legendFormat": "{{event_type}}",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "renameByName": { "Value": "count (24 h)", "event_type": "Event Type" } } }
+      ]
+    }
+
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["stellar", "oracle", "soroban"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(oracle_registered_sources_total, contract_id)",
+        "hide": 0,
+        "includeAll": false,
+        "name": "contract_id",
+        "label": "Contract ID",
+        "options": [],
+        "query": { "query": "label_values(oracle_registered_sources_total, contract_id)", "refId": "StandardVariableQuery" },
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Stellar Price Oracle",
+  "uid": "stellar-price-oracle",
+  "version": 1
+}

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# verify-deployment.sh — Post-deployment sanity check for the Price Oracle contract.
+#
+# Usage:
+#   ./scripts/verify-deployment.sh \
+#       --contract <CONTRACT_ID> \
+#       --admin    <ADMIN_IDENTITY>   \   # soroban identity name or keypair file
+#       --network  <NETWORK>             # testnet | mainnet | standalone
+#
+# Environment variables (alternative to flags):
+#   CONTRACT_ID, ADMIN_IDENTITY, NETWORK
+#
+# Exit codes: 0 = all checks passed, 1 = one or more checks failed.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+PASS="[${GREEN}PASS${NC}]"; FAIL="[${RED}FAIL${NC}]"
+FAILURES=0
+
+info()  { echo -e "${YELLOW}[INFO]${NC} $*"; }
+pass()  { echo -e "${PASS} $*"; }
+fail()  { echo -e "${FAIL} $*"; FAILURES=$((FAILURES + 1)); }
+
+check() {
+    local desc="$1"; local expected="$2"; local actual="$3"
+    if [[ "$actual" == *"$expected"* ]]; then
+        pass "$desc"
+    else
+        fail "$desc — expected '$expected', got '$actual'"
+    fi
+}
+
+invoke() {
+    # Invoke a read-only contract function and return its output.
+    stellar contract invoke \
+        --id    "$CONTRACT_ID" \
+        --source "$ADMIN_IDENTITY" \
+        --network "$NETWORK" \
+        -- "$@" 2>&1
+}
+
+invoke_auth() {
+    # Invoke a function that requires the admin to authorise (write op).
+    stellar contract invoke \
+        --id    "$CONTRACT_ID" \
+        --source "$ADMIN_IDENTITY" \
+        --network "$NETWORK" \
+        -- "$@" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --contract)  CONTRACT_ID="$2";       shift 2 ;;
+        --admin)     ADMIN_IDENTITY="$2";    shift 2 ;;
+        --network)   NETWORK="$2";           shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+CONTRACT_ID="${CONTRACT_ID:?'--contract <CONTRACT_ID> is required'}"
+ADMIN_IDENTITY="${ADMIN_IDENTITY:?'--admin <ADMIN_IDENTITY> is required'}"
+NETWORK="${NETWORK:-testnet}"
+
+# Resolve the admin's public key from the identity name so we can compare it
+# against what the contract reports.
+ADMIN_ADDRESS=$(stellar keys address "$ADMIN_IDENTITY" 2>/dev/null || echo "$ADMIN_IDENTITY")
+
+# Test identities — generated on the fly so they are never real accounts.
+TEST_SOURCE_SECRET=$(stellar keys generate --no-fund --overwrite _verify_source 2>/dev/null; stellar keys show _verify_source 2>/dev/null || true)
+TEST_SOURCE_ADDRESS=$(stellar keys address _verify_source 2>/dev/null || true)
+TEST_ASSET="VERIFY_TEST"
+TEST_PRICE="100000000"       # 1.0 with 8 decimals
+TEST_TIMESTAMP="1000000000"
+
+# ---------------------------------------------------------------------------
+# 1. Admin address
+# ---------------------------------------------------------------------------
+info "=== 1. Admin address ==="
+RESULT=$(invoke get_admin_address)
+check "admin address matches deployer" "$ADMIN_ADDRESS" "$RESULT"
+
+# ---------------------------------------------------------------------------
+# 2. min_sources and max_history
+# ---------------------------------------------------------------------------
+info "=== 2. min_sources / max_history ==="
+MIN_SRC=$(invoke get_min_sources_required)
+MAX_HIST=$(invoke get_max_history_length)
+[[ "$MIN_SRC" =~ ^[0-9]+$ ]] && pass "min_sources is a number ($MIN_SRC)" || fail "min_sources not numeric: $MIN_SRC"
+[[ "$MAX_HIST" =~ ^[0-9]+$ ]] && pass "max_history is a number ($MAX_HIST)" || fail "max_history not numeric: $MAX_HIST"
+
+# ---------------------------------------------------------------------------
+# 3. decimals, resolution, description
+# ---------------------------------------------------------------------------
+info "=== 3. decimals / resolution / description ==="
+DECIMALS=$(invoke get_decimals)
+RESOLUTION=$(invoke resolution)
+DESCRIPTION=$(invoke get_description)
+[[ "$DECIMALS" =~ ^[0-9]+$ ]] && pass "decimals is a number ($DECIMALS)" || fail "decimals not numeric: $DECIMALS"
+[[ "$RESOLUTION" =~ ^[0-9]+$ ]] && pass "resolution is a number ($RESOLUTION)" || fail "resolution not numeric: $RESOLUTION"
+[[ -n "$DESCRIPTION" ]] && pass "description is set" || fail "description is empty"
+
+# ---------------------------------------------------------------------------
+# 4. Register test source and verify
+# ---------------------------------------------------------------------------
+info "=== 4. Register test source ==="
+if [[ -z "$TEST_SOURCE_ADDRESS" ]]; then
+    fail "could not generate test source identity"
+else
+    invoke_auth add_source \
+        --address "$TEST_SOURCE_ADDRESS" \
+        --name    "verify-test-source" > /dev/null 2>&1 || true
+    SOURCE_CHECK=$(invoke is_source --address "$TEST_SOURCE_ADDRESS")
+    check "test source is registered" "true" "$SOURCE_CHECK"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Register test asset and verify
+# ---------------------------------------------------------------------------
+info "=== 5. Register test asset ==="
+invoke_auth register_asset --asset "$TEST_ASSET" > /dev/null 2>&1 || true
+ASSET_CHECK=$(invoke is_asset_registered --asset "$TEST_ASSET")
+check "test asset is registered" "true" "$ASSET_CHECK"
+
+# ---------------------------------------------------------------------------
+# 6. Submit test price and verify
+# ---------------------------------------------------------------------------
+info "=== 6. Submit test price ==="
+# Price submission must be signed by the source identity.
+stellar contract invoke \
+    --id      "$CONTRACT_ID" \
+    --source  "_verify_source" \
+    --network "$NETWORK" \
+    -- submit_price \
+        --source    "$TEST_SOURCE_ADDRESS" \
+        --asset     "$TEST_ASSET" \
+        --price     "$TEST_PRICE" \
+        --timestamp "$TEST_TIMESTAMP" > /dev/null 2>&1 || true
+
+PRICE_RESULT=$(invoke get_source_price \
+    --asset  "$TEST_ASSET" \
+    --source "$TEST_SOURCE_ADDRESS" 2>&1 || echo "")
+if [[ "$PRICE_RESULT" == *"$TEST_PRICE"* ]]; then
+    pass "submitted price is retrievable"
+else
+    fail "submitted price not found — got: $PRICE_RESULT"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Clean up test data
+# ---------------------------------------------------------------------------
+info "=== 7. Cleanup ==="
+invoke_auth remove_source   --address "$TEST_SOURCE_ADDRESS" > /dev/null 2>&1 || true
+invoke_auth unregister_asset --asset  "$TEST_ASSET"          > /dev/null 2>&1 || true
+
+SRC_AFTER=$(invoke  is_source          --address "$TEST_SOURCE_ADDRESS" 2>&1 || echo "false")
+ASSET_AFTER=$(invoke is_asset_registered --asset "$TEST_ASSET"           2>&1 || echo "false")
+check "test source removed"       "false" "$SRC_AFTER"
+check "test asset unregistered"   "false" "$ASSET_AFTER"
+
+# Clean up ephemeral local key
+stellar keys rm _verify_source 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo -e "${GREEN}All verification checks passed.${NC}"
+    exit 0
+else
+    echo -e "${RED}${FAILURES} check(s) failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #97 — post-deployment verification script
Closes #98 — monitoring dashboard template

## Changes

- `scripts/verify-deployment.sh` — queries and verifies admin address, min_sources, max_history, decimals, resolution, description; registers/verifies a test source and asset; submits and verifies a test price; cleans up; exits 0 on success
- `docs/monitoring/grafana-dashboard.json` — import-ready Grafana dashboard (latest prices, source submission frequency, aggregation events, error events, config changes, source/asset counts)
- `docs/monitoring/README.md` — setup instructions, metrics reference, alerting recommendations

## Testing

No Rust code changed. CI (fmt, clippy, tests) unaffected.