### PR TITLE
fix: resolve issues #75 #76 #77 #78

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,27 @@
+# Build artifacts
 /target
 **/*.wasm
+
+# Test snapshots
 test_snapshots/
+
+# Kiro AI agent state
 .kiro/
+
+# Node.js
 node_modules/
+npm-debug.log*
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
+# IDE
+.vscode/
+.idea/
+*.iml
+
+# OS
+.DS_Store
+Thumbs.db

--- a/contracts/price-oracle/src/admin.rs
+++ b/contracts/price-oracle/src/admin.rs
@@ -36,7 +36,7 @@ pub fn initialize(
     admin.require_auth();
     env.storage().persistent().set(&DataKey::Admin, &admin);
     env.storage().persistent().set(
-        &DataKey::MinSourcesRequired,
+        &DataKey::CfgMinSources,
         &if min_sources_required > 0 {
             min_sources_required
         } else {
@@ -44,7 +44,7 @@ pub fn initialize(
         },
     );
     env.storage().persistent().set(
-        &DataKey::MaxHistoryLength,
+        &DataKey::CfgMaxHistory,
         &if max_history_length > 0 {
             max_history_length
         } else {
@@ -53,30 +53,30 @@ pub fn initialize(
     );
     env.storage()
         .persistent()
-        .set(&DataKey::Resolution, &DEFAULT_RESOLUTION);
+        .set(&DataKey::CfgResolution, &DEFAULT_RESOLUTION);
     env.storage()
         .persistent()
-        .set(&DataKey::Decimals, &decimals);
+        .set(&DataKey::CfgDecimals, &decimals);
     env.storage()
         .persistent()
-        .set(&DataKey::Description, &description);
+        .set(&DataKey::CfgDescription, &description);
     env.storage().persistent().set(
-        &DataKey::OracleSources,
+        &DataKey::SrcRegistry,
         &OracleSources {
             sources: soroban_sdk::Vec::new(env),
             metadata: soroban_sdk::Map::new(env),
         },
     );
     env.storage().persistent().set(
-        &DataKey::RegisteredAssets,
+        &DataKey::AssetRegistry,
         &soroban_sdk::Vec::<Address>::new(env),
     );
     env.storage().persistent().set(
-        &DataKey::MaxInvalidSubmissions,
+        &DataKey::CfgMaxInvalidSubs,
         &DEFAULT_MAX_INVALID_SUBMISSIONS,
     );
     env.storage().persistent().set(
-        &DataKey::AggregationMethod,
+        &DataKey::CfgAggregationMethod,
         &(AggregationMethod::Median as u32),
     );
     emit_initialized(
@@ -140,12 +140,12 @@ pub fn set_min_sources_required(env: &Env, new_min: u32) {
     }
     env.storage()
         .persistent()
-        .set(&DataKey::MinSourcesRequired, &new_min);
+        .set(&DataKey::CfgMinSources, &new_min);
     MinSourcesChangedEvent { value: new_min }.publish(env);
 }
 
 pub fn get_min_sources_required(env: &Env) -> u32 {
-    let key = DataKey::MinSourcesRequired;
+    let key = DataKey::CfgMinSources;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -162,12 +162,12 @@ pub fn set_max_history_length(env: &Env, new_max: u32) {
     admin.require_auth();
     env.storage()
         .persistent()
-        .set(&DataKey::MaxHistoryLength, &new_max);
+        .set(&DataKey::CfgMaxHistory, &new_max);
     MaxHistoryChangedEvent { value: new_max }.publish(env);
 }
 
 pub fn get_max_history_length(env: &Env) -> u32 {
-    let key = DataKey::MaxHistoryLength;
+    let key = DataKey::CfgMaxHistory;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -184,7 +184,7 @@ pub fn set_resolution(env: &Env, new_resolution: u32) {
     admin.require_auth();
     env.storage()
         .persistent()
-        .set(&DataKey::Resolution, &new_resolution);
+        .set(&DataKey::CfgResolution, &new_resolution);
     ResolutionChangedEvent {
         value: new_resolution,
     }
@@ -192,7 +192,7 @@ pub fn set_resolution(env: &Env, new_resolution: u32) {
 }
 
 pub fn get_resolution(env: &Env) -> u32 {
-    let key = DataKey::Resolution;
+    let key = DataKey::CfgResolution;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -209,7 +209,7 @@ pub fn set_decimals(env: &Env, new_decimals: u32) {
     admin.require_auth();
     env.storage()
         .persistent()
-        .set(&DataKey::Decimals, &new_decimals);
+        .set(&DataKey::CfgDecimals, &new_decimals);
     DecimalsChangedEvent {
         value: new_decimals,
     }
@@ -217,7 +217,7 @@ pub fn set_decimals(env: &Env, new_decimals: u32) {
 }
 
 pub fn get_decimals(env: &Env) -> u32 {
-    let key = DataKey::Decimals;
+    let key = DataKey::CfgDecimals;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -237,7 +237,7 @@ pub fn set_description(env: &Env, new_description: String) {
     }
     env.storage()
         .persistent()
-        .set(&DataKey::Description, &new_description);
+        .set(&DataKey::CfgDescription, &new_description);
     DescriptionChangedEvent {
         description: new_description.clone(),
     }
@@ -245,7 +245,7 @@ pub fn set_description(env: &Env, new_description: String) {
 }
 
 pub fn get_description(env: &Env) -> String {
-    let key = DataKey::Description;
+    let key = DataKey::CfgDescription;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -258,7 +258,7 @@ pub fn get_description(env: &Env) -> String {
 }
 
 pub fn get_aggregation_method(env: &Env) -> u32 {
-    let key = DataKey::AggregationMethod;
+    let key = DataKey::CfgAggregationMethod;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -275,12 +275,12 @@ pub fn set_timestamp_threshold(env: &Env, threshold: u64) {
     admin.require_auth();
     env.storage()
         .persistent()
-        .set(&DataKey::TimestampThreshold, &threshold);
+        .set(&DataKey::CfgTimestampThreshold, &threshold);
     emit_timestamp_threshold_changed(env, admin, threshold);
 }
 
 pub fn get_timestamp_threshold(env: &Env) -> u64 {
-    let key = DataKey::TimestampThreshold;
+    let key = DataKey::CfgTimestampThreshold;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -300,12 +300,12 @@ pub fn set_max_price_deviation(env: &Env, deviation_basis_points: u32) {
     }
     env.storage()
         .persistent()
-        .set(&DataKey::MaxPriceDeviation, &deviation_basis_points);
+        .set(&DataKey::CfgMaxDeviation, &deviation_basis_points);
     emit_max_price_deviation_changed(env, admin, deviation_basis_points);
 }
 
 pub fn get_max_price_deviation(env: &Env) -> u32 {
-    let key = DataKey::MaxPriceDeviation;
+    let key = DataKey::CfgMaxDeviation;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -325,12 +325,12 @@ pub fn set_heartbeat_interval(env: &Env, interval: u64) {
     }
     env.storage()
         .persistent()
-        .set(&DataKey::HeartbeatInterval, &interval);
+        .set(&DataKey::CfgHeartbeatInterval, &interval);
     HeartbeatIntervalChangedEvent { value: interval }.publish(env);
 }
 
 pub fn get_heartbeat_interval(env: &Env) -> u64 {
-    let key = DataKey::HeartbeatInterval;
+    let key = DataKey::CfgHeartbeatInterval;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()

--- a/contracts/price-oracle/src/pause.rs
+++ b/contracts/price-oracle/src/pause.rs
@@ -8,7 +8,7 @@ pub fn pause(env: &Env) {
     let admin = get_admin(env);
     admin.require_auth();
 
-    env.storage().persistent().set(&DataKey::PauseFlag, &true);
+    env.storage().persistent().set(&DataKey::CfgPauseFlag, &true);
 
     ContractPausedEvent {
         admin: admin.clone(),
@@ -20,7 +20,7 @@ pub fn unpause(env: &Env) {
     let admin = get_admin(env);
     admin.require_auth();
 
-    env.storage().persistent().set(&DataKey::PauseFlag, &false);
+    env.storage().persistent().set(&DataKey::CfgPauseFlag, &false);
 
     ContractUnpausedEvent {
         admin: admin.clone(),
@@ -31,7 +31,7 @@ pub fn unpause(env: &Env) {
 pub fn is_paused(env: &Env) -> bool {
     env.storage()
         .persistent()
-        .get(&DataKey::PauseFlag)
+        .get(&DataKey::CfgPauseFlag)
         .unwrap_or(false)
 }
 

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -266,16 +266,13 @@ pub fn get_source_price(env: &Env, asset: Address, source: Address) -> PriceEntr
 
 pub fn get_all_prices(env: &Env, asset: Address) -> Vec<PriceEntry> {
     check_registered_asset(env, &asset);
+    // Read the sources list once; iterate without extra reads or writes per entry.
     let oracle_sources: OracleSources = read_oracle_sources(env);
     let mut prices: Vec<PriceEntry> = Vec::new(env);
     for i in 0..oracle_sources.sources.len() {
         let src = oracle_sources.sources.get_unchecked(i);
         let sub_key = DataKey::Submission(asset.clone(), src);
-        let sub: Option<PriceEntry> = env.storage().persistent().get(&sub_key);
-        if let Some(entry) = sub {
-            env.storage()
-                .persistent()
-                .extend_ttl(&sub_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+        if let Some(entry) = env.storage().persistent().get::<_, PriceEntry>(&sub_key) {
             prices.push_back(entry);
         }
     }
@@ -414,16 +411,6 @@ pub fn prices(env: &Env, asset: Asset, records: u32) -> Option<Vec<PriceData>> {
     Some(result)
 }
 
-#[allow(dead_code)]
-pub fn get_prices(env: &Env, assets: Vec<Address>) -> Vec<Option<AggregatePrice>> {
-    let mut results: Vec<Option<AggregatePrice>> = Vec::new(env);
-    for i in 0..assets.len() {
-        let asset = assets.get_unchecked(i);
-        let price = get_price(env, asset, 0);
-        results.push_back(price);
-    }
-    results
-}
 
 pub fn override_price(env: &Env, asset: Address, price: i128, reason: String, expiry_ledger: u32) {
     let admin = get_admin(env);
@@ -492,32 +479,5 @@ pub fn get_price_override(env: &Env, asset: Address) -> Option<PriceOverrideEntr
     env.storage().persistent().get(&override_key)
 }
 
-#[allow(dead_code)]
-pub fn get_price_change(env: &Env, asset: Address, ledgers_back: u32) -> Option<i128> {
-    check_registered_asset(env, &asset);
 
-    let current_price = get_price(env, asset.clone(), 0)?;
 
-    if current_price.price == 0 {
-        return None;
-    }
-
-    let current_ledger = env.ledger().sequence();
-    let target_ledger = current_ledger.saturating_sub(ledgers_back);
-
-    let hist_key = DataKey::PriceHistory(asset.clone(), target_ledger);
-    let historical_entry: Option<PriceHistoryEntry> = env.storage().temporary().get(&hist_key);
-
-    let old_price = match historical_entry {
-        Some(entry) => entry.price,
-        None => return None,
-    };
-
-    if old_price == 0 {
-        return None;
-    }
-
-    let diff = current_price.price.saturating_sub(old_price);
-    let change_percent = diff.saturating_mul(100) / old_price;
-    Some(change_percent)
-}

--- a/contracts/price-oracle/src/sources.rs
+++ b/contracts/price-oracle/src/sources.rs
@@ -17,13 +17,13 @@ pub fn add_source(env: &Env, source: Address, name: String) {
     if env
         .storage()
         .persistent()
-        .has(&DataKey::Source(source.clone()))
+        .has(&DataKey::SrcActive(source.clone()))
     {
         panic_with_error!(env, ErrorCode::SourceAlreadyExists);
     }
     env.storage()
         .persistent()
-        .set(&DataKey::Source(source.clone()), &true);
+        .set(&DataKey::SrcActive(source.clone()), &true);
 
     let mut oracle_sources: OracleSources = read_oracle_sources(env);
     oracle_sources.sources.push_back(source.clone());
@@ -31,7 +31,7 @@ pub fn add_source(env: &Env, source: Address, name: String) {
     oracle_sources.metadata.set(source.clone(), name);
     env.storage()
         .persistent()
-        .set(&DataKey::OracleSources, &oracle_sources);
+        .set(&DataKey::SrcRegistry, &oracle_sources);
     SourceAddedEvent {
         source: source.clone(),
         admin: admin.clone(),
@@ -46,13 +46,13 @@ pub fn remove_source(env: &Env, source: Address) {
     if !env
         .storage()
         .persistent()
-        .has(&DataKey::Source(source.clone()))
+        .has(&DataKey::SrcActive(source.clone()))
     {
         panic_with_error!(env, ErrorCode::SourceNotFound);
     }
     env.storage()
         .persistent()
-        .remove(&DataKey::Source(source.clone()));
+        .remove(&DataKey::SrcActive(source.clone()));
 
     let mut oracle_sources: OracleSources = read_oracle_sources(env);
     let mut new_sources: Vec<Address> = Vec::new(env);
@@ -67,7 +67,7 @@ pub fn remove_source(env: &Env, source: Address) {
     oracle_sources.metadata.remove(source);
     env.storage()
         .persistent()
-        .set(&DataKey::OracleSources, &oracle_sources);
+        .set(&DataKey::SrcRegistry, &oracle_sources);
     SourceRemovedEvent {
         source: removed_source,
         admin: admin.clone(),
@@ -76,7 +76,7 @@ pub fn remove_source(env: &Env, source: Address) {
 }
 
 pub fn is_source(env: &Env, source: Address) -> bool {
-    let key = DataKey::Source(source.clone());
+    let key = DataKey::SrcActive(source.clone());
     let exists: bool = env.storage().persistent().get(&key).unwrap_or(false);
     if exists {
         env.storage()
@@ -99,7 +99,7 @@ pub fn submit_heartbeat(env: &Env, source: Address) {
     let timestamp = env.ledger().timestamp();
     env.storage()
         .persistent()
-        .set(&DataKey::SourceHeartbeat(source.clone()), &timestamp);
+        .set(&DataKey::SrcHeartbeat(source.clone()), &timestamp);
 
     // If source was inactive, mark as active again
     let was_inactive = check_source_inactive(env, &source);
@@ -127,7 +127,7 @@ pub fn is_source_inactive(env: &Env, source: Address) -> bool {
     }
 
     // Check heartbeat timeout
-    let key = DataKey::SourceHeartbeat(source.clone());
+    let key = DataKey::SrcHeartbeat(source.clone());
     let last_heartbeat: Option<u64> = env.storage().persistent().get(&key);
 
     if let Some(hb_time) = last_heartbeat {
@@ -179,6 +179,6 @@ pub fn is_source_suspended(_env: &Env, _source: Address) -> bool {
 pub fn record_invalid_submission(_env: &Env, _source: Address) {}
 
 pub fn get_source_last_heartbeat(env: &Env, source: Address) -> u64 {
-    let key = DataKey::SourceHeartbeat(source);
+    let key = DataKey::SrcHeartbeat(source);
     env.storage().persistent().get(&key).unwrap_or(0u64)
 }

--- a/contracts/price-oracle/src/storage.rs
+++ b/contracts/price-oracle/src/storage.rs
@@ -9,7 +9,7 @@ pub fn get_admin(env: &Env) -> Address {
 }
 
 pub fn check_source(env: &Env, addr: &Address) {
-    let key = DataKey::Source(addr.clone());
+    let key = DataKey::SrcActive(addr.clone());
     let is_source: bool = env.storage().persistent().get(&key).unwrap_or(false);
     if !is_source {
         panic_with_error!(env, ErrorCode::NotAuthorized);
@@ -30,41 +30,57 @@ pub fn check_registered_asset(env: &Env, asset: &Address) {
         .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
 }
 
+/// Sort prices using heapsort — guaranteed O(n log n) worst-case, O(1) extra space.
+/// Preferred over quicksort to avoid O(n²) worst-case gas cost on adversarial inputs.
 pub fn sort_prices(prices: &mut soroban_sdk::Vec<i128>) {
     let n = prices.len();
     if n <= 1 {
         return;
     }
-    quicksort(prices, 0, n - 1);
-}
-
-fn quicksort(prices: &mut soroban_sdk::Vec<i128>, low: u32, high: u32) {
-    if low < high {
-        let pi = partition(prices, low, high);
-        if pi > 0 {
-            quicksort(prices, low, pi - 1);
+    // Build max-heap
+    let mut i = n / 2;
+    loop {
+        heapify(prices, n, i);
+        if i == 0 {
+            break;
         }
-        quicksort(prices, pi + 1, high);
+        i -= 1;
+    }
+    // Extract elements from heap one by one
+    let mut end = n - 1;
+    loop {
+        let tmp = prices.get_unchecked(0);
+        prices.set(0, prices.get_unchecked(end));
+        prices.set(end, tmp);
+        heapify(prices, end, 0);
+        if end == 0 {
+            break;
+        }
+        end -= 1;
     }
 }
 
-fn partition(prices: &mut soroban_sdk::Vec<i128>, low: u32, high: u32) -> u32 {
-    let pivot = prices.get_unchecked(high);
-    let mut i = low;
-    let mut j = low;
-    while j < high {
-        if prices.get_unchecked(j) <= pivot {
-            let tmp = prices.get_unchecked(i);
-            prices.set(i, prices.get_unchecked(j));
-            prices.set(j, tmp);
-            i += 1;
+/// Sift down the element at `root` within a heap of size `n` (iterative, no stack growth).
+fn heapify(prices: &mut soroban_sdk::Vec<i128>, n: u32, root: u32) {
+    let mut current = root;
+    loop {
+        let mut largest = current;
+        let left = 2 * current + 1;
+        let right = 2 * current + 2;
+        if left < n && prices.get_unchecked(left) > prices.get_unchecked(largest) {
+            largest = left;
         }
-        j += 1;
+        if right < n && prices.get_unchecked(right) > prices.get_unchecked(largest) {
+            largest = right;
+        }
+        if largest == current {
+            break;
+        }
+        let tmp = prices.get_unchecked(current);
+        prices.set(current, prices.get_unchecked(largest));
+        prices.set(largest, tmp);
+        current = largest;
     }
-    let tmp = prices.get_unchecked(i);
-    prices.set(i, prices.get_unchecked(high));
-    prices.set(high, tmp);
-    i
 }
 
 pub fn compute_median(prices: &soroban_sdk::Vec<i128>) -> i128 {
@@ -84,35 +100,6 @@ pub fn compute_median(prices: &soroban_sdk::Vec<i128>) -> i128 {
     }
 }
 
-#[allow(dead_code)]
-pub fn compute_trimmed_median(prices: &soroban_sdk::Vec<i128>, trim_percent: u32) -> i128 {
-    let n = prices.len();
-    if n == 0 {
-        return 0;
-    }
-    if trim_percent == 0 {
-        return compute_median(prices);
-    }
-
-    let mut sorted = prices.clone();
-    sort_prices(&mut sorted);
-
-    let trim_count = ((n.saturating_mul(trim_percent) / 100) / 2).min(n - 1);
-    if trim_count == 0 {
-        return compute_median(&sorted);
-    }
-
-    let mut trimmed: soroban_sdk::Vec<i128> = soroban_sdk::Vec::new(prices.env());
-    for i in trim_count..(n - trim_count) {
-        trimmed.push_back(sorted.get_unchecked(i));
-    }
-
-    if trimmed.is_empty() {
-        return sorted.get_unchecked(n / 2);
-    }
-
-    compute_median(&trimmed)
-}
 
 pub fn compute_mean(prices: &soroban_sdk::Vec<i128>) -> i128 {
     let n = prices.len();
@@ -156,7 +143,7 @@ pub fn compute_trimmed_mean(prices: &soroban_sdk::Vec<i128>, trim_percent: u32) 
 }
 
 pub fn read_registered_assets(env: &Env) -> Vec<Address> {
-    let key = DataKey::RegisteredAssets;
+    let key = DataKey::AssetRegistry;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -171,11 +158,11 @@ pub fn read_registered_assets(env: &Env) -> Vec<Address> {
 pub fn write_registered_assets(env: &Env, assets: &Vec<Address>) {
     env.storage()
         .persistent()
-        .set(&DataKey::RegisteredAssets, assets);
+        .set(&DataKey::AssetRegistry, assets);
 }
 
 pub fn read_oracle_sources(env: &Env) -> OracleSources {
-    let key = DataKey::OracleSources;
+    let key = DataKey::SrcRegistry;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()
@@ -191,16 +178,16 @@ pub fn read_oracle_sources(env: &Env) -> OracleSources {
 }
 
 pub fn is_source_inactive(env: &Env, source: &Address) -> bool {
-    let key = DataKey::InactiveSource(source.clone());
+    let key = DataKey::SrcInactive(source.clone());
     env.storage().persistent().get(&key).unwrap_or(false)
 }
 
 pub fn mark_source_inactive(env: &Env, source: &Address) {
-    let key = DataKey::InactiveSource(source.clone());
+    let key = DataKey::SrcInactive(source.clone());
     env.storage().persistent().set(&key, &true);
 }
 
 pub fn mark_source_active(env: &Env, source: &Address) {
-    let key = DataKey::InactiveSource(source.clone());
+    let key = DataKey::SrcInactive(source.clone());
     env.storage().persistent().remove(&key);
 }

--- a/contracts/price-oracle/src/timelock.rs
+++ b/contracts/price-oracle/src/timelock.rs
@@ -12,7 +12,7 @@ pub fn propose_operation(env: &Env, op_type: OperationType, data: &Bytes) -> u32
     let op_count: u32 = env
         .storage()
         .persistent()
-        .get(&DataKey::PendingOpCount)
+        .get(&DataKey::TlPendingOpCount)
         .unwrap_or(0);
     let op_id = op_count + 1;
 
@@ -26,10 +26,10 @@ pub fn propose_operation(env: &Env, op_type: OperationType, data: &Bytes) -> u32
 
     env.storage()
         .persistent()
-        .set(&DataKey::PendingOp(op_id), &pending_op);
+        .set(&DataKey::TlPendingOp(op_id), &pending_op);
     env.storage()
         .persistent()
-        .set(&DataKey::PendingOpCount, &op_id);
+        .set(&DataKey::TlPendingOpCount, &op_id);
 
     let op_type_num = match op_type {
         OperationType::Upgrade => 0,
@@ -60,14 +60,14 @@ pub fn execute_operation(env: &Env, op_id: u32) {
     let pending_op: PendingOperation = env
         .storage()
         .persistent()
-        .get(&DataKey::PendingOp(op_id))
+        .get(&DataKey::TlPendingOp(op_id))
         .ok_or_else(|| panic_with_error!(env, ErrorCode::OperationNotFound))
         .unwrap();
 
     let timelock_duration: u32 = env
         .storage()
         .persistent()
-        .get(&DataKey::TimelockDuration)
+        .get(&DataKey::CfgTimelockDuration)
         .unwrap_or(10);
     let current_ledger = env.ledger().sequence();
     let elapsed = current_ledger - pending_op.proposed_ledger;
@@ -78,7 +78,7 @@ pub fn execute_operation(env: &Env, op_id: u32) {
 
     env.storage()
         .persistent()
-        .remove(&DataKey::PendingOp(op_id));
+        .remove(&DataKey::TlPendingOp(op_id));
 
     let op_type_num = match pending_op.op_type {
         OperationType::Upgrade => 0,
@@ -106,13 +106,13 @@ pub fn cancel_operation(env: &Env, op_id: u32) {
     let pending_op: PendingOperation = env
         .storage()
         .persistent()
-        .get(&DataKey::PendingOp(op_id))
+        .get(&DataKey::TlPendingOp(op_id))
         .ok_or_else(|| panic_with_error!(env, ErrorCode::OperationNotFound))
         .unwrap();
 
     env.storage()
         .persistent()
-        .remove(&DataKey::PendingOp(op_id));
+        .remove(&DataKey::TlPendingOp(op_id));
 
     let op_type_num = match pending_op.op_type {
         OperationType::Upgrade => 0,
@@ -138,11 +138,11 @@ pub fn set_timelock_duration(env: &Env, duration: u32) {
     admin.require_auth();
     env.storage()
         .persistent()
-        .set(&DataKey::TimelockDuration, &duration);
+        .set(&DataKey::CfgTimelockDuration, &duration);
 }
 
 pub fn get_timelock_duration(env: &Env) -> u32 {
-    let key = DataKey::TimelockDuration;
+    let key = DataKey::CfgTimelockDuration;
     if env.storage().persistent().has(&key) {
         env.storage()
             .persistent()

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -4,70 +4,97 @@ pub use crate::errors::ErrorCode;
 
 /// Storage keys used to address contract state in persistent, temporary, and instance storage.
 ///
-/// Each variant uniquely identifies a piece of data stored on-chain. Address-keyed variants
-/// allow per-address records while symbol-keyed variants hold global configuration.
+/// ## Key Schema (namespace → variants)
+///
+/// | Namespace | Prefix | Variants |
+/// |-----------|--------|----------|
+/// | Admin identity | (none) | `Admin` |
+/// | Global config | `Cfg` | `CfgMinSources`, `CfgMaxHistory`, `CfgResolution`, `CfgDecimals`, `CfgDescription`, `CfgTimestampThreshold`, `CfgMaxDeviation`, `CfgHeartbeatInterval`, `CfgMaxInvalidSubs`, `CfgAggregationMethod`, `CfgPauseFlag`, `CfgTimelockDuration` |
+/// | Source registry | `Src` | `SrcActive(addr)`, `SrcRegistry`, `SrcHeartbeat(addr)`, `SrcInactive(addr)` |
+/// | Asset registry | `Asset` | `AssetRegistered(addr)`, `AssetRegistry`, `AssetMetadata(addr)`, `AssetMinPrice(addr)` |
+/// | Price data | `Price` | `Submission(asset, src)`, `PriceSubmissionLedger(asset, src)`, `Aggregate(asset)`, `PriceOverride(asset)`, `PriceDeviant(asset, src)` |
+/// | History | `Hist` | `PriceHistory(asset, ledger)`, `PriceHistoryLedgers(asset)` |
+/// | Timelock ops | `Tl` | `TlPendingOpCount`, `TlPendingOp(id)` |
+///
+/// Soroban encodes each variant name as an XDR `Symbol` discriminant, so variants are
+/// inherently collision-free. The namespace prefixes make the category explicit at the
+/// call site and prevent accidental re-use of a name across categories in future additions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum DataKey {
+    // --- Admin ---
     /// The contract administrator's address.
     Admin,
+
+    // --- Global config (prefix: Cfg) ---
+    /// Minimum number of contributing sources required to publish an aggregate price.
+    CfgMinSources,
+    /// Maximum number of history entries retained per asset before pruning.
+    CfgMaxHistory,
+    /// Price resolution window in seconds (SEP-40 `resolution` field).
+    CfgResolution,
+    /// Decimal precision applied to all prices stored by this contract.
+    CfgDecimals,
+    /// Human-readable description of this oracle instance.
+    CfgDescription,
+    /// Maximum allowed difference (in seconds) between a submitted timestamp and ledger time.
+    CfgTimestampThreshold,
+    /// Maximum allowed price deviation in basis points before flagging a submission.
+    CfgMaxDeviation,
+    /// Interval in seconds after which a source with no heartbeat is considered inactive.
+    CfgHeartbeatInterval,
+    /// Maximum number of invalid submissions allowed before a source is suspended.
+    CfgMaxInvalidSubs,
+    /// Currently active [`AggregationMethod`] stored as a `u32` discriminant.
+    CfgAggregationMethod,
+    /// Boolean flag indicating whether the contract is paused.
+    CfgPauseFlag,
+    /// Number of ledgers that must pass between proposing and executing a timelock operation.
+    CfgTimelockDuration,
+
+    // --- Source registry (prefix: Src) ---
     /// Existence flag for a registered oracle source (`true` when present).
-    Source(Address),
+    SrcActive(Address),
+    /// The [`OracleSources`] registry (list of sources and their metadata).
+    SrcRegistry,
+    /// Unix timestamp of the last heartbeat submitted by a source.
+    SrcHeartbeat(Address),
+    /// Inactive flag for a source.
+    SrcInactive(Address),
+
+    // --- Asset registry (prefix: Asset) ---
     /// Existence flag for a registered asset (`true` when present).
     AssetRegistered(Address),
-    /// Latest [`PriceEntry`] submitted by a specific source for a specific asset.
-    Submission(Address, Address),
-    /// Ledger sequence number of the last submission by a source for an asset.
-    SubmissionLedger(Address, Address),
-    /// Latest [`AggregatePrice`] computed across all contributing sources for an asset.
-    Aggregate(Address),
-    /// [`PriceHistoryEntry`] recorded at a specific ledger for an asset (temporary storage).
-    PriceHistory(Address, u32),
-    /// Ordered list of ledger numbers for which history exists for an asset.
-    PriceHistoryLedgers(Address),
-    /// The [`OracleSources`] registry (list of sources and their metadata).
-    OracleSources,
     /// Ordered list of all registered asset addresses.
-    RegisteredAssets,
-    /// Minimum number of contributing sources required to publish an aggregate price.
-    MinSourcesRequired,
-    /// Maximum number of history entries retained per asset before pruning.
-    MaxHistoryLength,
-    /// Price resolution window in seconds (SEP-40 `resolution` field).
-    Resolution,
-    /// Decimal precision applied to all prices stored by this contract.
-    Decimals,
-    /// Human-readable description of this oracle instance.
-    Description,
-    /// Maximum allowed difference (in seconds) between a submitted timestamp and ledger time.
-    TimestampThreshold,
-    /// Maximum allowed price deviation in basis points before flagging a submission.
-    MaxPriceDeviation,
-    /// Flag set when a source's submission deviates excessively from the current aggregate.
-    SubmissionDeviant(Address, Address),
-    /// Unix timestamp of the last heartbeat submitted by a source.
-    SourceHeartbeat(Address),
-    /// Interval in seconds after which a source with no heartbeat is considered inactive.
-    HeartbeatInterval,
-    /// Inactive flag for a source.
-    InactiveSource(Address),
-    /// Maximum number of invalid submissions allowed before a source is suspended.
-    MaxInvalidSubmissions,
-    /// Currently active [`AggregationMethod`] stored as a `u32` discriminant.
-    AggregationMethod,
+    AssetRegistry,
     /// Optional [`AssetMetadata`] attached to a registered asset.
     AssetMetadata(Address),
     /// Optional minimum accepted price (`i128`) for a registered asset.
     AssetMinPrice(Address),
-    /// Boolean flag indicating whether the contract is paused.
-    PauseFlag,
-    /// Monotonically incrementing counter used to assign IDs to pending operations.
-    PendingOpCount,
-    /// A [`PendingOperation`] awaiting timelock expiry before execution.
-    PendingOp(u32),
-    /// Number of ledgers that must pass between proposing and executing a timelock operation.
-    TimelockDuration,
+
+    // --- Price data (prefix: Price) ---
+    /// Latest [`PriceEntry`] submitted by a specific source for a specific asset.
+    Submission(Address, Address),
+    /// Ledger sequence number of the last submission by a source for an asset.
+    PriceSubmissionLedger(Address, Address),
+    /// Latest [`AggregatePrice`] computed across all contributing sources for an asset.
+    Aggregate(Address),
+    /// Active price override for an asset.
     PriceOverride(Address),
+    /// Flag set when a source's submission deviates excessively from the current aggregate.
+    PriceDeviant(Address, Address),
+
+    // --- History (prefix: Hist via PriceHistory name) ---
+    /// [`PriceHistoryEntry`] recorded at a specific ledger for an asset (temporary storage).
+    PriceHistory(Address, u32),
+    /// Ordered list of ledger numbers for which history exists for an asset.
+    PriceHistoryLedgers(Address),
+
+    // --- Timelock operations (prefix: Tl) ---
+    /// Monotonically incrementing counter used to assign IDs to pending operations.
+    TlPendingOpCount,
+    /// A [`PendingOperation`] awaiting timelock expiry before execution.
+    TlPendingOp(u32),
 }
 
 /// A price submission from a single oracle source for a specific asset.


### PR DESCRIPTION
#78 - Optimize get_all_prices: read sources list once, remove
      per-entry extend_ttl write ops inside read function

#76 - Replace quicksort with iterative heapsort in sort_prices
      for guaranteed O(n log n) worst-case gas cost

#75 - Remove dead code: compute_trimmed_median, get_prices,
      get_price_change and their #[allow(dead_code)] attributes

#77 - Add storage key namespacing to DataKey enum:
      Cfg* for config, Src* for sources, Asset* for assets,
      Tl* for timelock ops; document key schema in enum comment

chore: update .gitignore with env, IDE, and OS patterns

Closes #78 
Closes #76 
Closes #75 
Closes #77 
