### PR TITLE
feat: implement submit_prices batch function (#119)

### DIFF
--- a/contracts/price-oracle/src/batch_tests.rs
+++ b/contracts/price-oracle/src/batch_tests.rs
@@ -1,0 +1,204 @@
+//! Tests for the `submit_prices` batch function (#119).
+
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env, Vec,
+};
+
+use crate::test_helpers::{register_test_asset, register_test_source, setup_contract};
+
+fn ledger_at(e: &Env, seq: u32, ts: u64) {
+    e.ledger().set(LedgerInfo {
+        timestamp: ts,
+        protocol_version: 26,
+        sequence_number: seq,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 4096,
+    });
+}
+
+// --- helpers ---
+
+fn make_batch(e: &Env, tuples: &[(Address, i128, u64)]) -> Vec<(Address, i128, u64)> {
+    let mut v: Vec<(Address, i128, u64)> = Vec::new(e);
+    for (a, p, t) in tuples {
+        v.push_back((a.clone(), *p, *t));
+    }
+    v
+}
+
+// --- tests ---
+
+/// Batch with a single entry should produce an aggregate exactly like submit_price.
+#[test]
+fn test_submit_prices_single_entry() {
+    let e = Env::default();
+    ledger_at(&e, 100, 1_000_000);
+    let (client, _) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "S1");
+    let asset = register_test_asset(&e, &client);
+
+    let batch = make_batch(&e, &[(asset.clone(), 5_000i128, 1_000_000u64)]);
+    client.submit_prices(&source, &batch);
+
+    let price = client.get_price(&asset, &0u64).unwrap();
+    assert_eq!(price.price, 5_000i128);
+}
+
+/// Batch with two assets in one call — both should get aggregated.
+#[test]
+fn test_submit_prices_multiple_assets() {
+    let e = Env::default();
+    ledger_at(&e, 100, 1_000_000);
+    let (client, _) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "S1");
+    let asset1 = register_test_asset(&e, &client);
+    let asset2 = register_test_asset(&e, &client);
+
+    let batch = make_batch(
+        &e,
+        &[
+            (asset1.clone(), 1_000i128, 1_000_000u64),
+            (asset2.clone(), 2_000i128, 1_000_000u64),
+        ],
+    );
+    client.submit_prices(&source, &batch);
+
+    assert_eq!(client.get_price(&asset1, &0u64).unwrap().price, 1_000i128);
+    assert_eq!(client.get_price(&asset2, &0u64).unwrap().price, 2_000i128);
+}
+
+/// Authorization is checked once — a single mock_all_auths covers the whole batch.
+#[test]
+fn test_submit_prices_auth_checked_once() {
+    let e = Env::default();
+    ledger_at(&e, 100, 1_000_000);
+    let (client, _) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "S1");
+    let asset1 = register_test_asset(&e, &client);
+    let asset2 = register_test_asset(&e, &client);
+    let asset3 = register_test_asset(&e, &client);
+
+    // mock_all_auths is already set by setup_contract via create_contract
+    let batch = make_batch(
+        &e,
+        &[
+            (asset1.clone(), 100i128, 1_000_000u64),
+            (asset2.clone(), 200i128, 1_000_000u64),
+            (asset3.clone(), 300i128, 1_000_000u64),
+        ],
+    );
+    client.submit_prices(&source, &batch);
+
+    assert!(client.get_price(&asset1, &0u64).is_some());
+    assert!(client.get_price(&asset2, &0u64).is_some());
+    assert!(client.get_price(&asset3, &0u64).is_some());
+}
+
+/// Invalid price (zero) in the batch aborts the entire call (atomicity).
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_submit_prices_invalid_price_aborts_all() {
+    let e = Env::default();
+    ledger_at(&e, 100, 1_000_000);
+    let (client, _) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "S1");
+    let asset1 = register_test_asset(&e, &client);
+    let asset2 = register_test_asset(&e, &client);
+
+    // Second entry has price = 0 — should panic with InvalidPrice
+    let batch = make_batch(
+        &e,
+        &[
+            (asset1.clone(), 100i128, 1_000_000u64),
+            (asset2.clone(), 0i128, 1_000_000u64), // INVALID
+        ],
+    );
+    client.submit_prices(&source, &batch);
+}
+
+/// Unregistered asset in the batch aborts the entire call.
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_submit_prices_unregistered_asset_aborts() {
+    let e = Env::default();
+    ledger_at(&e, 100, 1_000_000);
+    let (client, _) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "S1");
+    let asset1 = register_test_asset(&e, &client);
+    let bad_asset = Address::generate(&e); // Not registered
+
+    let batch = make_batch(
+        &e,
+        &[
+            (asset1.clone(), 100i128, 1_000_000u64),
+            (bad_asset.clone(), 200i128, 1_000_000u64),
+        ],
+    );
+    client.submit_prices(&source, &batch);
+}
+
+/// Aggregation is triggered after batch — multiple sources reach min_sources threshold.
+#[test]
+fn test_submit_prices_aggregation_triggered() {
+    let e = Env::default();
+    ledger_at(&e, 100, 1_000_000);
+    let (client, _) = setup_contract(&e);
+    client.set_min_sources_required(&2u32);
+
+    let source1 = register_test_source(&e, &client, "S1");
+    let source2 = register_test_source(&e, &client, "S2");
+    let asset = register_test_asset(&e, &client);
+
+    // Source1 submits via batch, source2 via batch — together they meet min_sources=2
+    let batch1 = make_batch(&e, &[(asset.clone(), 100i128, 1_000_000u64)]);
+    client.submit_prices(&source1, &batch1);
+    // Only 1 source so far — no aggregate yet
+    assert!(client.get_price(&asset, &0u64).is_none());
+
+    let batch2 = make_batch(&e, &[(asset.clone(), 200i128, 1_000_000u64)]);
+    client.submit_prices(&source2, &batch2);
+    // Now 2 sources — median of [100, 200] = 150
+    let agg = client.get_price(&asset, &0u64).unwrap();
+    assert_eq!(agg.price, 150i128);
+    assert_eq!(agg.num_sources, 2u32);
+}
+
+/// Empty batch is accepted without error.
+#[test]
+fn test_submit_prices_empty_batch() {
+    let e = Env::default();
+    ledger_at(&e, 100, 1_000_000);
+    let (client, _) = setup_contract(&e);
+    let source = register_test_source(&e, &client, "S1");
+
+    let batch: Vec<(Address, i128, u64)> = Vec::new(&e);
+    // Should not panic
+    client.submit_prices(&source, &batch);
+}
+
+/// Future timestamp beyond threshold aborts atomically.
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_submit_prices_future_timestamp_aborts() {
+    let e = Env::default();
+    ledger_at(&e, 100, 1_000);
+    let (client, _) = setup_contract(&e);
+    client.set_min_sources_required(&1u32);
+    let source = register_test_source(&e, &client, "S1");
+    let asset = register_test_asset(&e, &client);
+
+    // Default threshold is 300s; timestamp 10_000 is 9000s in future
+    let batch = make_batch(&e, &[(asset.clone(), 100i128, 10_000u64)]);
+    client.submit_prices(&source, &batch);
+}

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -18,6 +18,9 @@ mod override_tests;
 #[cfg(test)]
 mod prop_tests;
 
+#[cfg(test)]
+mod batch_tests;
+
 pub use types::{
     AggregatePrice, AggregationMethod, Asset, DataKey, ErrorCode, OracleSources, PriceData,
     PriceEntry, PriceHistoryEntry, PriceOverrideEntry,
@@ -573,6 +576,25 @@ impl PriceOracleContract {
     /// * [`ErrorCode::InvalidTimestamp`] — if `timestamp` is too far in the future.
     pub fn submit_price(env: Env, source: Address, asset: Address, price: i128, timestamp: u64) {
         prices::submit_price(&env, source, asset, price, timestamp);
+    }
+
+    /// Submits prices for multiple assets in a single atomic transaction.
+    ///
+    /// Authorization is checked once for `source`. All entries are validated before any
+    /// are written — if any entry fails validation the entire call panics (all-or-nothing).
+    /// Aggregation is triggered for each asset after all submissions are stored.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban execution environment.
+    /// * `source` - Address of the submitting oracle source. Must authorize this call.
+    /// * `asset_prices` - List of `(asset, price, timestamp)` tuples to submit.
+    ///
+    /// # Errors
+    ///
+    /// Same error conditions as `submit_price`, applied per entry.
+    pub fn submit_prices(env: Env, source: Address, asset_prices: Vec<(Address, i128, u64)>) {
+        prices::submit_prices(&env, source, asset_prices);
     }
 
     /// Returns the latest aggregate price for an asset, filtered by a maximum age.

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -18,56 +18,87 @@ use crate::types::{
     PriceHistoryEntry, PriceOverrideEntry,
 };
 
-pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, timestamp: u64) {
+/// Submits prices for multiple assets in a single atomic transaction.
+///
+/// Authorization is checked once for `source`. Each `(asset, price, timestamp)` tuple
+/// is validated individually; if any entry is invalid the entire call panics (atomicity).
+/// Aggregation is triggered for each asset after all submissions are stored.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban execution environment.
+/// * `source` - Address of the submitting oracle source. Must authorize this call.
+/// * `asset_prices` - Ordered list of `(asset, price, timestamp)` tuples.
+///
+/// # Errors
+///
+/// Same error conditions as `submit_price`, applied per entry.
+pub fn submit_prices(env: &Env, source: Address, asset_prices: Vec<(Address, i128, u64)>) {
     check_not_paused(env);
     source.require_auth();
     check_source(env, &source);
-    check_registered_asset(env, &asset);
 
     if crate::sources::is_source_suspended(env, source.clone()) {
         panic_with_error!(env, ErrorCode::NotAuthorized);
     }
 
-    if price <= 0 {
-        crate::sources::record_invalid_submission(env, source.clone());
-        panic_with_error!(env, ErrorCode::InvalidPrice);
-    }
-
-    let min_price = crate::assets::get_min_price(env, asset.clone());
-    if price < min_price {
-        panic_with_error!(env, ErrorCode::PriceBelowMinimum);
-    }
-
+    let decimals = get_decimals(env);
     let ledger_time = env.ledger().timestamp();
     let threshold = get_timestamp_threshold(env);
-    if timestamp > ledger_time.saturating_add(threshold) {
-        crate::sources::record_invalid_submission(env, source.clone());
-        panic_with_error!(env, ErrorCode::InvalidTimestamp);
-    }
-
-    let decimals = get_decimals(env);
     let current_ledger = env.ledger().sequence();
 
-    let entry = PriceEntry {
-        price,
-        timestamp,
-        source: source.clone(),
-        decimals,
-        last_updated: current_ledger,
-    };
+    // Validate all entries first for atomicity — any invalid entry aborts the whole call.
+    for i in 0..asset_prices.len() {
+        let (ref asset, price, timestamp) = asset_prices.get_unchecked(i);
+        check_registered_asset(env, asset);
 
-    env.storage()
-        .persistent()
-        .set(&DataKey::Submission(asset.clone(), source.clone()), &entry);
+        if price <= 0 {
+            crate::sources::record_invalid_submission(env, source.clone());
+            panic_with_error!(env, ErrorCode::InvalidPrice);
+        }
 
-    PriceSubmittedEvent {
-        asset: asset.clone(),
-        source: source.clone(),
-        price,
-        timestamp,
+        let min_price = crate::assets::get_min_price(env, asset.clone());
+        if price < min_price {
+            panic_with_error!(env, ErrorCode::PriceBelowMinimum);
+        }
+
+        if timestamp > ledger_time.saturating_add(threshold) {
+            crate::sources::record_invalid_submission(env, source.clone());
+            panic_with_error!(env, ErrorCode::InvalidTimestamp);
+        }
     }
-    .publish(env);
 
+    // All valid — store submissions and trigger aggregation.
+    for i in 0..asset_prices.len() {
+        let (asset, price, timestamp) = asset_prices.get_unchecked(i);
+
+        let entry = PriceEntry {
+            price,
+            timestamp,
+            source: source.clone(),
+            decimals,
+            last_updated: current_ledger,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Submission(asset.clone(), source.clone()), &entry);
+
+        PriceSubmittedEvent {
+            asset: asset.clone(),
+            source: source.clone(),
+            price,
+            timestamp,
+        }
+        .publish(env);
+
+        // Trigger aggregation for this asset.
+        aggregate_asset(env, &asset, current_ledger, decimals);
+    }
+}
+
+/// Internal helper: re-aggregate all sources for a single asset and write history.
+fn aggregate_asset(env: &Env, asset: &Address, current_ledger: u32, decimals: u32) {
     let min_required = get_min_sources_required(env);
     let oracle_sources: OracleSources = read_oracle_sources(env);
     let total_sources = oracle_sources.sources.len();
@@ -76,8 +107,8 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
     let mut latest_timestamp: u64 = 0;
     let mut contributing_sources: u32 = 0;
 
-    for i in 0..total_sources {
-        let src = oracle_sources.sources.get_unchecked(i);
+    for j in 0..total_sources {
+        let src = oracle_sources.sources.get_unchecked(j);
         let sub_key = DataKey::Submission(asset.clone(), src.clone());
         let sub: Option<PriceEntry> = env.storage().persistent().get(&sub_key);
         if let Some(entry_data) = sub {
@@ -142,7 +173,6 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
                 &history_entry,
             );
 
-            // Track ledger in history index for pruning
             let ledgers_key = DataKey::PriceHistoryLedgers(asset.clone());
             let mut ledger_list: soroban_sdk::Vec<u32> = env
                 .storage()
@@ -183,6 +213,59 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
         }
         .publish(env);
     }
+}
+
+pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, timestamp: u64) {
+    check_not_paused(env);
+    source.require_auth();
+    check_source(env, &source);
+    check_registered_asset(env, &asset);
+
+    if crate::sources::is_source_suspended(env, source.clone()) {
+        panic_with_error!(env, ErrorCode::NotAuthorized);
+    }
+
+    if price <= 0 {
+        crate::sources::record_invalid_submission(env, source.clone());
+        panic_with_error!(env, ErrorCode::InvalidPrice);
+    }
+
+    let min_price = crate::assets::get_min_price(env, asset.clone());
+    if price < min_price {
+        panic_with_error!(env, ErrorCode::PriceBelowMinimum);
+    }
+
+    let ledger_time = env.ledger().timestamp();
+    let threshold = get_timestamp_threshold(env);
+    if timestamp > ledger_time.saturating_add(threshold) {
+        crate::sources::record_invalid_submission(env, source.clone());
+        panic_with_error!(env, ErrorCode::InvalidTimestamp);
+    }
+
+    let decimals = get_decimals(env);
+    let current_ledger = env.ledger().sequence();
+
+    let entry = PriceEntry {
+        price,
+        timestamp,
+        source: source.clone(),
+        decimals,
+        last_updated: current_ledger,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Submission(asset.clone(), source.clone()), &entry);
+
+    PriceSubmittedEvent {
+        asset: asset.clone(),
+        source: source.clone(),
+        price,
+        timestamp,
+    }
+    .publish(env);
+
+    aggregate_asset(env, &asset, current_ledger, decimals);
 }
 
 pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePrice> {


### PR DESCRIPTION
## Summary

Resolves #119.

## Changes

### New endpoint: `submit_prices`

```rust
pub fn submit_prices(env: Env, source: Address, asset_prices: Vec<(Address, i128, u64)>)
```

Allows a registered oracle source to submit prices for multiple assets in a single transaction.

**Acceptance criteria satisfied:**
- ✅ New function `submit_prices(source, asset_prices: Vec<(Address, i128, u64)>)`
- ✅ Each tuple contains: asset, price, timestamp
- ✅ All submissions are processed atomically (validate all first, then write all)
- ✅ Authorization checked once for `source`
- ✅ Individual price validation (price > 0, above min, timestamp in bounds) applied per entry
- ✅ Aggregation triggered after all submissions
- ✅ Tests verify batching, partial failure (invalid price aborts), and atomicity

### Refactor

Extracted an internal `aggregate_asset()` helper from `submit_price` so both functions share the same aggregation logic without duplication.

### Tests (`batch_tests.rs`)

| Test | Covers |
|------|--------|
| `test_submit_prices_single_entry` | Basic batch of 1 produces aggregate |
| `test_submit_prices_multiple_assets` | 2 assets in one call both aggregated |
| `test_submit_prices_auth_checked_once` | 3-asset batch works with single auth |
| `test_submit_prices_invalid_price_aborts_all` | price=0 aborts whole batch |
| `test_submit_prices_unregistered_asset_aborts` | Unregistered asset aborts |
| `test_submit_prices_aggregation_triggered` | Batch triggers aggregation when min_sources met |
| `test_submit_prices_empty_batch` | Empty batch is a no-op |
| `test_submit_prices_future_timestamp_aborts` | Future timestamp aborts whole batch |

## Testing

```
test result: ok. 100 passed; 0 failed; 0 ignored
```
Zero clippy warnings. Formatting clean.