### PR TITLE
Add confidence-based price queries derived from source dispersion

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -183,6 +183,10 @@ impl PriceOracleContract {
         prices::get_price(&env, asset, max_age)
     }
 
+    pub fn get_price_with_confidence(env: Env, asset: Address) -> Option<(AggregatePrice, u32)> {
+        prices::get_price_with_confidence(&env, asset)
+    }
+
     pub fn get_source_price(env: Env, asset: Address, source: Address) -> PriceEntry {
         prices::get_source_price(&env, asset, source)
     }

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -10,8 +10,8 @@ use crate::events::{
 };
 use crate::pause::check_not_paused;
 use crate::storage::{
-    check_registered_asset, check_source, compute_mean, compute_median, compute_trimmed_mean,
-    read_oracle_sources, LEDGER_BUMP, LEDGER_THRESHOLD,
+    check_registered_asset, check_source, compute_confidence_bps, compute_mean, compute_median,
+    compute_trimmed_mean, read_oracle_sources, LEDGER_BUMP, LEDGER_THRESHOLD,
 };
 use crate::types::{
     AggregatePrice, Asset, DataKey, ErrorCode, OracleSources, PriceData, PriceEntry,
@@ -218,6 +218,20 @@ pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePri
         .persistent()
         .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
     Some(result)
+}
+
+pub fn get_price_with_confidence(env: &Env, asset: Address) -> Option<(AggregatePrice, u32)> {
+    let aggregate = get_price(env, asset.clone(), 0)?;
+
+    let mut prices: Vec<i128> = Vec::new(env);
+    let entries = get_all_prices(env, asset.clone());
+    for i in 0..entries.len() {
+        let entry = entries.get_unchecked(i);
+        prices.push_back(entry.price);
+    }
+
+    let confidence_bps = compute_confidence_bps(&prices);
+    Some((aggregate, confidence_bps))
 }
 
 pub fn get_source_price(env: &Env, asset: Address, source: Address) -> PriceEntry {

--- a/contracts/price-oracle/src/storage.rs
+++ b/contracts/price-oracle/src/storage.rs
@@ -126,6 +126,56 @@ pub fn compute_mean(prices: &soroban_sdk::Vec<i128>) -> i128 {
     sum / (n as i128)
 }
 
+fn integer_sqrt(value: i128) -> i128 {
+    if value <= 1 {
+        return value;
+    }
+
+    let mut lo = 0i128;
+    let mut hi = value;
+    while lo + 1 < hi {
+        let mid = lo + (hi - lo) / 2;
+        if mid.saturating_mul(mid) <= value {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    lo
+}
+
+pub fn compute_stddev(prices: &soroban_sdk::Vec<i128>) -> u32 {
+    let n = prices.len();
+    if n == 0 {
+        return 0;
+    }
+
+    let mean = compute_mean(prices);
+    let mut sum_sq: i128 = 0;
+    for i in 0..n {
+        let diff = prices.get_unchecked(i) - mean;
+        sum_sq = sum_sq.saturating_add(diff.saturating_mul(diff));
+    }
+
+    let variance = sum_sq / (n as i128);
+    integer_sqrt(variance).max(0) as u32
+}
+
+pub fn compute_confidence_bps(prices: &soroban_sdk::Vec<i128>) -> u32 {
+    let n = prices.len();
+    if n == 0 {
+        return 0;
+    }
+
+    let mean = compute_mean(prices);
+    if mean <= 0 {
+        return 0;
+    }
+
+    let stddev = compute_stddev(prices) as u128;
+    ((stddev.saturating_mul(10000u128)) / (mean as u128)) as u32
+}
+
 pub fn compute_trimmed_mean(prices: &soroban_sdk::Vec<i128>, trim_percent: u32) -> i128 {
     let n = prices.len();
     if n == 0 {

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -259,6 +259,41 @@ fn test_submit_price_median_even() {
 }
 
 #[test]
+fn test_get_price_with_confidence_tracks_source_dispersion() {
+    let e = Env::default();
+    ledger_default(&e, 100, 1234567890);
+
+    let (client, _) = setup_contract(&e);
+    let source1 = register_test_source(&e, &client, "A");
+    let source2 = register_test_source(&e, &client, "B");
+    let source3 = register_test_source(&e, &client, "C");
+    client.set_min_sources_required(&3u32);
+
+    let tight_asset = register_test_asset(&e, &client);
+    let wide_asset = register_test_asset(&e, &client);
+
+    submit_test_price(&client, &source1, &tight_asset, 1000i128, 1234567890);
+    submit_test_price(&client, &source2, &tight_asset, 1001i128, 1234567890);
+    submit_test_price(&client, &source3, &tight_asset, 1002i128, 1234567890);
+
+    submit_test_price(&client, &source1, &wide_asset, 1000i128, 1234567890);
+    submit_test_price(&client, &source2, &wide_asset, 1400i128, 1234567890);
+    submit_test_price(&client, &source3, &wide_asset, 1800i128, 1234567890);
+
+    let (tight_aggregate, tight_confidence) =
+        client.get_price_with_confidence(&tight_asset).unwrap();
+    let (wide_aggregate, wide_confidence) = client.get_price_with_confidence(&wide_asset).unwrap();
+
+    assert_eq!(tight_aggregate.price, 1001i128);
+    assert_eq!(tight_aggregate.num_sources, 3u32);
+    assert_eq!(wide_aggregate.price, 1400i128);
+    assert_eq!(wide_aggregate.num_sources, 3u32);
+    assert!(tight_confidence < wide_confidence);
+    assert!(tight_confidence < 200u32);
+    assert!(wide_confidence > 2000u32);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #0)")]
 fn test_submit_price_unauthorized_source() {
     let e = Env::default();


### PR DESCRIPTION
## Summary
Adds a new confidence-aware price query that returns both the aggregate price and a basis-point confidence value derived from source dispersion.

## What changed
- Added `get_price_with_confidence(asset)` as a new contract entrypoint.
- Calculated confidence from the same contributing source submissions used for aggregation.
- Derived a dispersion-based confidence metric using a standard-deviation-style calculation and converted it to basis points relative to the mean.
- Added regression tests covering both tight clustering and wide-spread submissions.

## Verification
- Built the contract for `wasm32v1-none`
- Ran the full `price-oracle` test suite successfully (`77 passed, 0 failed`)

Closes #234 