### PR TITLE
fix: reconcile botched merges so the crate compiles and most tests pass

### DIFF
--- a/contracts/price-oracle/src/admin.rs
+++ b/contracts/price-oracle/src/admin.rs
@@ -1,17 +1,17 @@
 use soroban_sdk::{panic_with_error, symbol_short, Address, Bytes, Env, String};
 
 use crate::events::{
-    emit_initialized, emit_max_price_deviation_changed, emit_timestamp_threshold_changed,
-    AdminChangedEvent, ContractUpgradedEvent, DecimalsChangedEvent, DescriptionChangedEvent,
-    HeartbeatIntervalChangedEvent, MaxHistoryChangedEvent, MinSourcesChangedEvent,
-    QueryRateLimitChangedEvent, ResolutionChangedEvent,
+    emit_admin_action, emit_initialized, emit_max_price_deviation_changed,
+    emit_timestamp_threshold_changed, AdminChangedEvent, AggCooldownChangedEvent,
+    AssetResolutionSetEvent, ContractUpgradedEvent, DecimalsChangedEvent, DescriptionChangedEvent,
+    EventsPerCallChangedEvent, HeartbeatIntervalChangedEvent, HistoryPerAssetChangedEvent,
+    InterpolationChangedEvent, MaxAggSourcesChangedEvent, MaxHistoryChangedEvent,
+    MaxSourcesChangedEvent, MinSourcesChangedEvent, QueryRateLimitChangedEvent,
+    ResolutionChangedEvent, SubmitIntervalChangedEvent,
 };
 use crate::storage::{
     get_admin, read_oracle_sources, read_subscription_plans, write_subscription_plans,
     DEFAULT_QUERY_RATE_LIMIT, LEDGER_BUMP, LEDGER_THRESHOLD,
-    HeartbeatIntervalChangedEvent, MaxAggregationSourcesChangedEvent, MaxEventsPerCallChangedEvent,
-    MaxHistoryChangedEvent, MaxHistoryPerAssetChangedEvent, MinSourcesChangedEvent,
-    ResolutionChangedEvent,
 };
 use crate::types::{AggregationMethod, DataKey, ErrorCode, OracleSources};
 
@@ -100,10 +100,9 @@ pub fn initialize(
         &DataKey::CfgAggregationMethod,
         &(AggregationMethod::Median as u32),
     );
-    env.storage().persistent().set(
-        &DataKey::QueryRateLimit,
-        &DEFAULT_QUERY_RATE_LIMIT,
-    );
+    env.storage()
+        .persistent()
+        .set(&DataKey::QueryRateLimit, &DEFAULT_QUERY_RATE_LIMIT);
     let init_admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
     emit_initialized(
         env,
@@ -390,13 +389,208 @@ pub fn get_heartbeat_interval(env: &Env) -> u64 {
         .unwrap_or(DEFAULT_HEARTBEAT_INTERVAL)
 }
 
+// --- Issue #94: per-asset history cap ---
+
+pub fn set_max_history_per_asset(env: &Env, new_max: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .set(&DataKey::MaxHistoryPerAsset, &new_max);
+    HistoryPerAssetChangedEvent { value: new_max }.publish(env);
+}
+
+pub fn get_max_history_per_asset(env: &Env) -> u32 {
+    let key = DataKey::MaxHistoryPerAsset;
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(DEFAULT_MAX_HISTORY_PER_ASSET)
+}
+
+// --- Issue #92: max events per call ---
+
+pub fn set_max_events_per_call(env: &Env, new_max: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .set(&DataKey::MaxEventsPerCall, &new_max);
+    EventsPerCallChangedEvent { value: new_max }.publish(env);
+}
+
+pub fn get_max_events_per_call(env: &Env) -> u32 {
+    let key = DataKey::MaxEventsPerCall;
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(DEFAULT_MAX_EVENTS_PER_CALL)
+}
+
+// --- Issue #93: max aggregation sources ---
+
+pub fn set_max_aggregation_sources(env: &Env, new_max: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .set(&DataKey::MaxAggregationSources, &new_max);
+    MaxAggSourcesChangedEvent { value: new_max }.publish(env);
+}
+
+pub fn get_max_aggregation_sources(env: &Env) -> u32 {
+    let key = DataKey::MaxAggregationSources;
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(DEFAULT_MAX_AGGREGATION_SOURCES)
+}
+
+// --- #67: Per-asset resolution ---
+
+pub fn set_asset_resolution(env: &Env, asset: Address, resolution: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    let key = DataKey::AssetResolution(asset.clone());
+    if resolution == 0 {
+        env.storage().persistent().remove(&key);
+    } else {
+        env.storage().persistent().set(&key, &resolution);
+    }
+    AssetResolutionSetEvent {
+        asset,
+        admin: admin.clone(),
+        resolution,
+    }
+    .publish(env);
+    emit_admin_action(env, symbol_short!("set_ares"), admin, Bytes::new(env));
+}
+
+pub fn get_asset_resolution(env: &Env, asset: Address) -> u32 {
+    let key = DataKey::AssetResolution(asset);
+    if let Some(r) = env.storage().persistent().get::<_, u32>(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+        r
+    } else {
+        get_resolution(env)
+    }
+}
+
+// --- #69: Periodic aggregation trigger cooldown ---
+
+pub fn set_aggregation_cooldown(env: &Env, cooldown_ledgers: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .set(&DataKey::AggregationCooldown, &cooldown_ledgers);
+    AggCooldownChangedEvent { cooldown_ledgers }.publish(env);
+    emit_admin_action(env, symbol_short!("set_acd"), admin, Bytes::new(env));
+}
+
+pub fn get_aggregation_cooldown(env: &Env) -> u32 {
+    let key = DataKey::AggregationCooldown;
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage().persistent().get(&key).unwrap_or(10)
+}
+
+// --- #70: Minimum submission interval ---
+
+pub fn set_min_submission_interval(env: &Env, interval_ledgers: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .set(&DataKey::MinSubmissionInterval, &interval_ledgers);
+    SubmitIntervalChangedEvent { interval_ledgers }.publish(env);
+    emit_admin_action(env, symbol_short!("set_msi"), admin, Bytes::new(env));
+}
+
+pub fn get_min_submission_interval(env: &Env) -> u32 {
+    let key = DataKey::MinSubmissionInterval;
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage().persistent().get(&key).unwrap_or(0)
+}
+
+// --- Historical price interpolation toggle ---
+
+pub fn set_interpolation_enabled(env: &Env, enabled: bool) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .set(&DataKey::InterpolationEnabled, &enabled);
+    InterpolationChangedEvent { enabled }.publish(env);
+    emit_admin_action(env, symbol_short!("set_intp"), admin, Bytes::new(env));
+}
+
+pub fn get_interpolation_enabled(env: &Env) -> bool {
+    let key = DataKey::InterpolationEnabled;
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage().persistent().get(&key).unwrap_or(true)
+}
+
+// --- Maximum registered oracle sources ---
+
+pub fn set_max_sources(env: &Env, new_max: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .set(&DataKey::MaxSources, &new_max);
+    MaxSourcesChangedEvent { value: new_max }.publish(env);
+    emit_admin_action(env, symbol_short!("set_msrc"), admin, Bytes::new(env));
+}
+
+pub fn get_max_sources(env: &Env) -> u32 {
+    let key = DataKey::MaxSources;
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage().persistent().get(&key).unwrap_or(0)
+}
+
 pub fn set_query_rate_limit(env: &Env, max_per_ledger: u32) {
     let admin = get_admin(env);
     admin.require_auth();
     env.storage()
         .persistent()
         .set(&DataKey::QueryRateLimit, &max_per_ledger);
-    QueryRateLimitChangedEvent { value: max_per_ledger }.publish(env);
+    QueryRateLimitChangedEvent {
+        value: max_per_ledger,
+    }
+    .publish(env);
 }
 
 pub fn get_query_rate_limit(env: &Env) -> u32 {

--- a/contracts/price-oracle/src/alerts.rs
+++ b/contracts/price-oracle/src/alerts.rs
@@ -25,12 +25,9 @@
 //! - `AlertSubscriptionTtl` → default TTL in ledgers (u32).
 //! - `AlertLastPrice(asset)` → last recorded price (i128) for deviation comparison.
 
-use soroban_sdk::{panic_with_error, vec, Address, Env, Symbol, Vec};
+use soroban_sdk::{panic_with_error, Address, Env, IntoVal, Symbol, Vec};
 
-use crate::events::{
-    AlertCallbackFailedEvent, AlertSubscribedEvent, AlertSubscriptionExpiredEvent,
-    AlertTriggeredEvent,
-};
+use crate::events::{AlertSubscribedEvent, AlertSubscriptionExpiredEvent, AlertTriggeredEvent};
 use crate::storage::{get_admin, LEDGER_BUMP, LEDGER_THRESHOLD};
 use crate::types::{AlertSubscription, DataKey, ErrorCode};
 
@@ -145,11 +142,7 @@ pub fn unsubscribe_from_alerts(env: &Env, consumer: Address, asset: Address) {
 }
 
 /// Returns the subscription record for a (consumer, asset) pair, or `None`.
-pub fn get_subscription(
-    env: &Env,
-    consumer: Address,
-    asset: Address,
-) -> Option<AlertSubscription> {
+pub fn get_subscription(env: &Env, consumer: Address, asset: Address) -> Option<AlertSubscription> {
     let key = DataKey::AlertSubscription(consumer, asset);
     env.storage().persistent().get(&key)
 }
@@ -180,9 +173,8 @@ pub fn dispatch_alerts(env: &Env, asset: &Address, old_price: i128, new_price: i
 
     // Compute movement in basis points: |new - old| * 10_000 / old.
     let diff = (new_price - old_price).abs();
-    let movement_bps: u32 = ((diff as u128)
-        .saturating_mul(BPS_PRECISION as u128)
-        / (old_price as u128)) as u32;
+    let movement_bps: u32 =
+        ((diff as u128).saturating_mul(BPS_PRECISION as u128) / (old_price as u128)) as u32;
 
     // Nothing to dispatch if zero movement.
     if movement_bps == 0 {
@@ -241,10 +233,10 @@ pub fn dispatch_alerts(env: &Env, asset: &Address, old_price: i128, new_price: i
             let args: soroban_sdk::Vec<soroban_sdk::Val> = {
                 let mut v = soroban_sdk::Vec::new(env);
                 // Pass: asset, old_price, new_price, movement_bps
-                v.push_back(asset.clone().into());
-                v.push_back(old_price.into());
-                v.push_back(new_price.into());
-                v.push_back((movement_bps as i128).into());
+                v.push_back(asset.clone().into_val(env));
+                v.push_back(old_price.into_val(env));
+                v.push_back(new_price.into_val(env));
+                v.push_back((movement_bps as i128).into_val(env));
                 v
             };
 

--- a/contracts/price-oracle/src/asset_registry_gas_tests.rs
+++ b/contracts/price-oracle/src/asset_registry_gas_tests.rs
@@ -49,8 +49,6 @@ fn bench_asset_registry_lookup_50_assets() {
     // Measure CPU instructions + memory bytes through budget API.
     e.budget().reset_default();
     let _ = client.is_asset_registered(&query_asset);
-    let cpu = e.budget().cpu_instruction_count();
-    let mem = e.budget().memory_bytes_count();
-
-    println!("bench_asset_registry_lookup_50_assets: cpu={cpu} mem={mem}");
+    let _cpu = e.budget().cpu_instruction_cost();
+    let _mem = e.budget().memory_bytes_cost();
 }

--- a/contracts/price-oracle/src/commit_reveal_tests.rs
+++ b/contracts/price-oracle/src/commit_reveal_tests.rs
@@ -52,7 +52,7 @@ fn make_hash(e: &Env, price: i128, salt_val: u64, round_ledger: u32) -> BytesN<3
     for b in round_bytes.iter() {
         preimage.push_back(*b);
     }
-    e.crypto().sha256(&preimage)
+    e.crypto().sha256(&preimage).into()
 }
 
 fn salt_bytes(e: &Env, val: u64) -> Bytes {
@@ -183,7 +183,13 @@ fn test_reveal_hash_mismatch() {
 
     advance_ledger(&e, 22);
     // Wrong price → hash mismatch
-    client.reveal_price(&source, &asset, &99_999i128, &salt_bytes(&e, salt_val), &round);
+    client.reveal_price(
+        &source,
+        &asset,
+        &99_999i128,
+        &salt_bytes(&e, salt_val),
+        &round,
+    );
 }
 
 #[test]

--- a/contracts/price-oracle/src/correlation.rs
+++ b/contracts/price-oracle/src/correlation.rs
@@ -185,8 +185,7 @@ pub fn validate_correlation(
             continue; // this pair doesn't involve the submitted asset
         };
 
-        let band_key =
-            DataKey::CorrelationBand(pair.base_asset.clone(), pair.quote_asset.clone());
+        let band_key = DataKey::CorrelationBand(pair.base_asset.clone(), pair.quote_asset.clone());
         let band: CorrelationBand = match env.storage().persistent().get(&band_key) {
             Some(b) => b,
             None => continue,

--- a/contracts/price-oracle/src/cross_ref_tests.rs
+++ b/contracts/price-oracle/src/cross_ref_tests.rs
@@ -70,9 +70,7 @@ fn test_add_reference_oracle_unauthorized() {
     let mapping: Map<Address, Address> = Map::new(&e);
 
     clear_auth(&e);
-    assert!(client
-        .try_add_reference_oracle(&mock_id, &mapping)
-        .is_err());
+    assert!(client.try_add_reference_oracle(&mock_id, &mapping).is_err());
 }
 
 #[test]
@@ -98,40 +96,38 @@ fn test_cross_ref_deviation_threshold_default() {
     let (client, _admin) = setup_contract(&e);
 
     // Default is 500 bps (5%)
-    assert_eq!(client.get_cross_ref_deviation_threshold(), 500u32);
+    assert_eq!(client.get_cross_ref_deviation_bps(), 500u32);
 }
 
 #[test]
-fn test_set_cross_ref_deviation_threshold() {
+fn test_set_cross_ref_deviation_bps() {
     let e = Env::default();
     e.mock_all_auths();
     let (client, _admin) = setup_contract(&e);
 
-    client.set_cross_ref_deviation_threshold(&1000u32);
-    assert_eq!(client.get_cross_ref_deviation_threshold(), 1000u32);
+    client.set_cross_ref_deviation_bps(&1000u32);
+    assert_eq!(client.get_cross_ref_deviation_bps(), 1000u32);
 }
 
 #[test]
-fn test_set_cross_ref_deviation_threshold_unauthorized() {
+fn test_set_cross_ref_deviation_bps_unauthorized() {
     let e = Env::default();
     e.mock_all_auths();
     let (client, _admin) = setup_contract(&e);
 
     clear_auth(&e);
-    assert!(client
-        .try_set_cross_ref_deviation_threshold(&1000u32)
-        .is_err());
+    assert!(client.try_set_cross_ref_deviation_bps(&1000u32).is_err());
 }
 
 #[test]
 #[should_panic(expected = "Error(Contract, #10)")]
-fn test_set_cross_ref_deviation_threshold_too_high() {
+fn test_set_cross_ref_deviation_bps_too_high() {
     let e = Env::default();
     e.mock_all_auths();
     let (client, _admin) = setup_contract(&e);
 
     // 100_001 exceeds the maximum allowed 100_000
-    client.set_cross_ref_deviation_threshold(&100_001u32);
+    client.set_cross_ref_deviation_bps(&100_001u32);
 }
 
 #[test]
@@ -194,7 +190,7 @@ fn test_get_cross_reference_returns_prices_no_deviation() {
     client.add_reference_oracle(&mock_id, &mapping);
 
     // Set threshold to 500 bps (5%)
-    client.set_cross_ref_deviation_threshold(&500u32);
+    client.set_cross_ref_deviation_bps(&500u32);
 
     let result = client.get_cross_reference(&our_asset).unwrap();
     assert_eq!(result.our_price, price);
@@ -228,7 +224,7 @@ fn test_get_cross_reference_detects_deviation_below_threshold() {
     client.add_reference_oracle(&mock_id, &mapping);
 
     // Threshold at 5% — 2% deviation should NOT trigger the event
-    client.set_cross_ref_deviation_threshold(&500u32);
+    client.set_cross_ref_deviation_bps(&500u32);
 
     let result = client.get_cross_reference(&our_asset).unwrap();
     assert_eq!(result.our_price, our_price);
@@ -262,7 +258,7 @@ fn test_get_cross_reference_emits_event_on_deviation() {
     client.add_reference_oracle(&mock_id, &mapping);
 
     // Threshold at 5% — 10% deviation should trigger the CrossRefDeviationEvent
-    client.set_cross_ref_deviation_threshold(&500u32);
+    client.set_cross_ref_deviation_bps(&500u32);
 
     let result = client.get_cross_reference(&our_asset).unwrap();
     assert_eq!(result.our_price, our_price);

--- a/contracts/price-oracle/src/cross_reference.rs
+++ b/contracts/price-oracle/src/cross_reference.rs
@@ -2,7 +2,9 @@ use soroban_sdk::{panic_with_error, Address, Env, IntoVal, Map, Symbol, Val, Vec
 
 use crate::events::CrossRefDeviationEvent;
 use crate::storage::{get_admin, LEDGER_BUMP, LEDGER_THRESHOLD};
-use crate::types::{AggregatePrice, CrossReferenceResult, DataKey, ErrorCode, ReferenceOracleEntry};
+use crate::types::{
+    AggregatePrice, CrossReferenceResult, DataKey, ErrorCode, ReferenceOracleEntry,
+};
 
 const DEFAULT_CROSS_REF_DEVIATION_BPS: u32 = 500; // 5%
 
@@ -11,11 +13,7 @@ const DEFAULT_CROSS_REF_DEVIATION_BPS: u32 = 500; // 5%
 /// The `asset_mapping` maps our asset `Address` values to the corresponding asset
 /// `Address` values used by the reference oracle contract. On each
 /// `get_cross_reference` call the contract will invoke `lastprice` on this oracle.
-pub fn add_reference_oracle(
-    env: &Env,
-    contract_id: Address,
-    asset_mapping: Map<Address, Address>,
-) {
+pub fn add_reference_oracle(env: &Env, contract_id: Address, asset_mapping: Map<Address, Address>) {
     let admin = get_admin(env);
     admin.require_auth();
 
@@ -121,12 +119,11 @@ pub fn get_cross_reference(env: &Env, asset: Address) -> Option<CrossReferenceRe
                 let mut args: Vec<Val> = Vec::new(env);
                 args.push_back(mapped_asset.into_val(env));
 
-                let ref_price: i128 =
-                    env.invoke_contract(&entry.contract_id, &func, args);
+                let ref_price: i128 = env.invoke_contract(&entry.contract_id, &func, args);
 
                 if ref_price > 0 {
                     let deviation_bps = compute_deviation_bps(our_price, ref_price);
-                    let threshold_bps = get_cross_ref_deviation_threshold(env);
+                    let threshold_bps = get_cross_ref_deviation_bps(env);
 
                     if deviation_bps > threshold_bps {
                         CrossRefDeviationEvent {
@@ -156,7 +153,7 @@ pub fn get_cross_reference(env: &Env, asset: Address) -> Option<CrossReferenceRe
 
 /// Sets the deviation threshold (in basis points) above which a [`CrossRefDeviationEvent`]
 /// is emitted during a cross-reference check. Must be in the range `[0, 100_000]`.
-pub fn set_cross_ref_deviation_threshold(env: &Env, threshold_bps: u32) {
+pub fn set_cross_ref_deviation_bps(env: &Env, threshold_bps: u32) {
     let admin = get_admin(env);
     admin.require_auth();
     if threshold_bps > 100_000 {
@@ -171,7 +168,7 @@ pub fn set_cross_ref_deviation_threshold(env: &Env, threshold_bps: u32) {
 
 /// Returns the current cross-reference deviation threshold in basis points.
 /// Defaults to `500` (5 %).
-pub fn get_cross_ref_deviation_threshold(env: &Env) -> u32 {
+pub fn get_cross_ref_deviation_bps(env: &Env) -> u32 {
     let key = DataKey::CrossRefDeviationThreshold;
     if env.storage().persistent().has(&key) {
         env.storage()

--- a/contracts/price-oracle/src/errors.rs
+++ b/contracts/price-oracle/src/errors.rs
@@ -15,6 +15,7 @@ use soroban_sdk::contracterror;
 /// | 20–29  | Source management      |
 /// | 30–39  | Commit-reveal (#187)   |
 /// | 40–49  | Finality gadget (#188) |
+/// | 50–59  | Relayer & misc         |
 #[contracterror]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ErrorCode {
@@ -111,4 +112,14 @@ pub enum ErrorCode {
     InsufficientFinality = 43,
     /// A reorg was detected via ledger hash chain inconsistency.
     ReorgDetected = 44,
+
+    // ── 50–59: Relayer & misc ────────────────────────────────────────────────
+    /// The caller is not a registered and approved relayer.
+    RelayerNotAuthorized = 50,
+    /// `add_relayer` was called for an address that is already an approved relayer.
+    RelayerAlreadyExists = 51,
+    /// Source reputation is too high to be eligible for slashing.
+    ReputationTooHighToSlash = 52,
+    /// Maximum number of alert subscriptions has been reached.
+    MaxSubscriptionsReached = 53,
 }

--- a/contracts/price-oracle/src/events.rs
+++ b/contracts/price-oracle/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contractevent, symbol_short, Address, Bytes, String, Symbol};
+use soroban_sdk::{contractevent, Address, Bytes, String, Symbol};
 
 /// Publishes a generic admin-action audit event.
 ///
@@ -555,7 +555,7 @@ pub struct AggregationTriggeredEvent {
 /// Emitted when the aggregation cooldown is updated.
 #[contractevent]
 #[derive(Clone)]
-pub struct AggregationCooldownChangedEvent {
+pub struct AggCooldownChangedEvent {
     pub cooldown_ledgers: u32,
 }
 
@@ -564,7 +564,7 @@ pub struct AggregationCooldownChangedEvent {
 /// Emitted when the minimum submission interval is updated.
 #[contractevent]
 #[derive(Clone)]
-pub struct MinSubmissionIntervalChangedEvent {
+pub struct SubmitIntervalChangedEvent {
     pub interval_ledgers: u32,
 }
 
@@ -696,7 +696,7 @@ pub struct SourceHealthChangedEvent {
 /// Emitted when the max_inactive_ledgers configuration is changed.
 #[contractevent]
 #[derive(Clone)]
-pub struct MaxInactiveLedgersChangedEvent {
+pub struct InactiveLedgersChangedEvent {
     /// The new maximum inactive ledgers threshold.
     pub value: u32,
 }
@@ -862,4 +862,408 @@ pub struct PricePendingFinalityEvent {
     pub committed_ledger: u32,
     /// Ledger after which the price will be considered final.
     pub finality_ledger: u32,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #171: Source Reputation & Slashing Events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when an oracle source stakes tokens into contract custody.
+#[contractevent]
+#[derive(Clone)]
+pub struct SourceStakedEvent {
+    /// Address of the source that staked.
+    #[topic]
+    pub source: Address,
+    /// Amount staked in this transaction (stroops).
+    pub amount: i128,
+    /// New total stake after this transaction (stroops).
+    pub total_stake: i128,
+}
+
+/// Emitted when a source's staked tokens are returned upon deregistration.
+#[contractevent]
+#[derive(Clone)]
+pub struct SourceUnstakedEvent {
+    /// Address of the source whose stake was returned.
+    #[topic]
+    pub source: Address,
+    /// Amount returned (may be less than original stake if slashed).
+    pub amount_returned: i128,
+}
+
+/// Emitted when an admin slashes a portion of a source's locked stake.
+#[contractevent]
+#[derive(Clone)]
+pub struct SourceSlashedEvent {
+    /// Address of the slashed source.
+    #[topic]
+    pub source: Address,
+    /// Amount slashed (moved to treasury) in stroops.
+    pub slash_amount: i128,
+    /// Remaining stake after slashing.
+    pub remaining_stake: i128,
+    /// Configured slash percentage applied.
+    pub slash_percent: u32,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #172: Cross-Asset Correlation Events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when a correlation ratio band is configured or updated.
+#[contractevent]
+#[derive(Clone)]
+pub struct CorrelationBandSetEvent {
+    /// Base asset of the pair.
+    #[topic]
+    pub base_asset: Address,
+    /// Quote asset of the pair.
+    #[topic]
+    pub quote_asset: Address,
+    /// Minimum acceptable ratio (scaled by RATIO_PRECISION = 10^7).
+    pub min_ratio: u128,
+    /// Maximum acceptable ratio (scaled by RATIO_PRECISION = 10^7).
+    pub max_ratio: u128,
+    /// Whether the check is currently enabled.
+    pub enabled: bool,
+}
+
+/// Emitted when a submitted price causes a correlation ratio violation.
+#[contractevent]
+#[derive(Clone)]
+pub struct CorrelationViolationEvent {
+    /// Base asset of the violated pair.
+    #[topic]
+    pub base_asset: Address,
+    /// Quote asset of the violated pair.
+    #[topic]
+    pub quote_asset: Address,
+    /// Source that submitted the out-of-band price.
+    #[topic]
+    pub source: Address,
+    /// The price just submitted.
+    pub submitted_price: i128,
+    /// The current aggregate price of the counterpart asset.
+    pub counterpart_price: i128,
+    /// Computed ratio (scaled by RATIO_PRECISION).
+    pub ratio: u128,
+    /// Configured minimum ratio.
+    pub min_ratio: u128,
+    /// Configured maximum ratio.
+    pub max_ratio: u128,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #173: Tiered Consumer Access Events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when a new consumer registers with a tier.
+#[contractevent]
+#[derive(Clone)]
+pub struct ConsumerRegisteredEvent {
+    /// Address of the newly registered consumer.
+    #[topic]
+    pub consumer: Address,
+    /// Tier discriminant (0=Free, 1=Basic, 2=Premium).
+    pub tier: u32,
+    /// Unix timestamp when the subscription expires (0 = no expiry for Free tier).
+    pub subscription_expiry_ts: u64,
+}
+
+/// Emitted when a consumer changes to a different tier.
+#[contractevent]
+#[derive(Clone)]
+pub struct ConsumerTierChangedEvent {
+    /// Address of the consumer changing tiers.
+    #[topic]
+    pub consumer: Address,
+    /// Old tier discriminant.
+    pub old_tier: u32,
+    /// New tier discriminant.
+    pub new_tier: u32,
+}
+
+/// Emitted when a subscription fee is paid.
+#[contractevent]
+#[derive(Clone)]
+pub struct TierFeePaidEvent {
+    /// Consumer that paid the fee.
+    #[topic]
+    pub consumer: Address,
+    /// Tier discriminant the fee was paid for.
+    pub tier: u32,
+    /// Amount paid in stroops.
+    pub amount: i128,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #174: Price Deviation Alert Events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when a consumer successfully subscribes to price deviation alerts.
+#[contractevent]
+#[derive(Clone)]
+pub struct AlertSubscribedEvent {
+    /// Address of the subscribing consumer.
+    #[topic]
+    pub consumer: Address,
+    /// Asset being monitored.
+    #[topic]
+    pub asset: Address,
+    /// Movement threshold in basis points.
+    pub threshold_bps: u32,
+    /// TTL in ledgers for this subscription.
+    pub ttl_ledgers: u32,
+}
+
+/// Emitted when an alert threshold is breached and a callback is dispatched.
+#[contractevent]
+#[derive(Clone)]
+pub struct AlertTriggeredEvent {
+    /// Subscriber that was notified.
+    #[topic]
+    pub consumer: Address,
+    /// Asset whose price moved.
+    #[topic]
+    pub asset: Address,
+    /// Previous aggregate price.
+    pub old_price: i128,
+    /// New aggregate price.
+    pub new_price: i128,
+    /// Actual price movement in basis points.
+    pub movement_bps: u32,
+    /// The configured threshold that was exceeded.
+    pub threshold_bps: u32,
+}
+
+/// Emitted when a consumer's callback invocation fails.
+#[contractevent]
+#[derive(Clone)]
+pub struct AlertCallbackFailedEvent {
+    /// Subscriber whose callback failed.
+    #[topic]
+    pub consumer: Address,
+    /// Asset being monitored.
+    #[topic]
+    pub asset: Address,
+}
+
+/// Emitted when a subscription expires and is pruned.
+#[contractevent]
+#[derive(Clone)]
+pub struct AlertSubscriptionExpiredEvent {
+    /// Consumer whose subscription expired.
+    #[topic]
+    pub consumer: Address,
+    /// Asset the subscription was for.
+    #[topic]
+    pub asset: Address,
+    /// Ledger at which expiry was detected.
+    pub expired_ledger: u32,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Off-chain relayer network integration events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when the admin approves a new relayer.
+///
+/// Topics: `relayer`, `admin`
+#[contractevent]
+#[derive(Clone)]
+pub struct RelayerAddedEvent {
+    /// Address of the newly approved relayer.
+    #[topic]
+    pub relayer: Address,
+    /// Address of the admin who approved the relayer.
+    #[topic]
+    pub admin: Address,
+    /// Human-readable display name for the relayer.
+    pub name: String,
+}
+
+/// Emitted when the admin revokes a relayer's approval.
+///
+/// Topics: `relayer`, `admin`
+#[contractevent]
+#[derive(Clone)]
+pub struct RelayerRemovedEvent {
+    /// Address of the relayer whose approval was revoked.
+    #[topic]
+    pub relayer: Address,
+    /// Address of the admin who performed the revocation.
+    #[topic]
+    pub admin: Address,
+}
+
+/// Emitted when an approved relayer successfully submits a price on behalf of a source.
+///
+/// Topics: `asset`, `source`, `relayer`
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceRelayedEvent {
+    /// Address of the asset being priced.
+    #[topic]
+    pub asset: Address,
+    /// Address of the oracle source whose price data was relayed.
+    #[topic]
+    pub source: Address,
+    /// Address of the relayer that submitted the transaction.
+    #[topic]
+    pub relayer: Address,
+    /// Raw price value scaled by `10^decimals`.
+    pub price: i128,
+    /// Unix timestamp (seconds) of the price observation.
+    pub timestamp: u64,
+}
+
+/// Publishes the relayer-fee-changed event.
+///
+/// Uses manual event publishing because `i128` fields in `#[contractevent]` may
+/// trigger edge cases in some tooling.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban execution environment.
+/// * `admin` - Address of the admin who set the new fee.
+/// * `fee` - New fee per submission in stroops.
+#[allow(deprecated)]
+pub fn emit_relayer_fee_set(env: &soroban_sdk::Env, admin: Address, fee: i128) {
+    let sym = soroban_sdk::symbol_short!("rfee");
+    env.events().publish((sym, admin), (fee,));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cross-reference oracle check events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when a cross-reference check detects that our price deviates from a reference
+/// oracle's price by more than the configured threshold.
+///
+/// Topics: `asset`, `ref_contract`
+#[contractevent]
+#[derive(Clone)]
+pub struct CrossRefDeviationEvent {
+    /// Address of the asset for which the deviation was detected.
+    #[topic]
+    pub asset: Address,
+    /// Contract address of the reference oracle that reported the diverging price.
+    #[topic]
+    pub ref_contract: Address,
+    /// Our current aggregated price for the asset.
+    pub our_price: i128,
+    /// Price reported by the reference oracle.
+    pub ref_price: i128,
+    /// Absolute deviation between the two prices in basis points (1 % = 100 bps).
+    pub deviation_bps: u32,
+    /// Configured deviation threshold (in basis points) that was exceeded.
+    pub threshold_bps: u32,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #92/#93/#94: history cap, event spam protection, max aggregation sources
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when per-asset history is pruned beyond `max_history_per_asset` (issue #94).
+///
+/// Topics: `asset`
+#[contractevent]
+#[derive(Clone)]
+pub struct HistoryPerAssetPrunedEvent {
+    #[topic]
+    pub asset: Address,
+    /// Ledger removed from the history index.
+    pub pruned_ledger: u32,
+    /// Remaining entry count after pruning.
+    pub remaining: u32,
+}
+
+/// Emitted when the `max_history_per_asset` limit is changed (issue #94).
+#[contractevent]
+#[derive(Clone)]
+pub struct HistoryPerAssetChangedEvent {
+    pub value: u32,
+}
+
+/// Emitted when the event-per-call cap is exceeded in a single invocation (issue #92).
+/// The transaction still succeeds; this is a warning only.
+///
+/// Topics: `asset`
+#[contractevent]
+#[derive(Clone)]
+pub struct EventLimitWarningEvent {
+    #[topic]
+    pub asset: Address,
+    /// Number of events that would have been emitted.
+    pub event_count: u32,
+    /// Configured cap that was exceeded.
+    pub max_events: u32,
+}
+
+/// Emitted when the `max_events_per_call` limit is changed (issue #92).
+#[contractevent]
+#[derive(Clone)]
+pub struct EventsPerCallChangedEvent {
+    pub value: u32,
+}
+
+/// Emitted when the `max_aggregation_sources` limit is changed (issue #93).
+#[contractevent]
+#[derive(Clone)]
+pub struct MaxAggSourcesChangedEvent {
+    pub value: u32,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #112: Storage migration events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when a storage migration is resumed from a previously saved cursor.
+#[contractevent]
+#[derive(Clone)]
+pub struct MigrationResumedEvent {
+    #[topic]
+    pub admin: Address,
+    pub cursor: u32,
+}
+
+/// Emitted when a new storage migration begins.
+#[contractevent]
+#[derive(Clone)]
+pub struct MigrationStartedEvent {
+    #[topic]
+    pub admin: Address,
+    pub from_version: u32,
+    pub to_version: u32,
+    pub started_ledger: u32,
+}
+
+/// Emitted when a storage migration finishes processing all items.
+#[contractevent]
+#[derive(Clone)]
+pub struct MigrationCompletedEvent {
+    #[topic]
+    pub admin: Address,
+    pub from_version: u32,
+    pub to_version: u32,
+    pub items_processed: u32,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Misc admin config events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emitted when historical-price interpolation is enabled or disabled.
+#[contractevent]
+#[derive(Clone)]
+pub struct InterpolationChangedEvent {
+    pub enabled: bool,
+}
+
+/// Emitted when the maximum number of registered oracle sources is changed.
+#[contractevent]
+#[derive(Clone)]
+pub struct MaxSourcesChangedEvent {
+    pub value: u32,
 }

--- a/contracts/price-oracle/src/fee_tests.rs
+++ b/contracts/price-oracle/src/fee_tests.rs
@@ -95,8 +95,8 @@ fn test_fee_charged_on_price_query() {
     let collector = Address::generate(&e);
     client.set_fee_collector(&collector);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 150i128);
@@ -117,8 +117,8 @@ fn test_fee_not_charged_with_zero_fee() {
     // Fee is 0 by default
     assert_eq!(client.get_query_fee(), 0i128);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 150i128);
@@ -138,8 +138,8 @@ fn test_admin_bypasses_fee() {
 
     client.set_query_fee(&50i128);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 150i128);

--- a/contracts/price-oracle/src/finality.rs
+++ b/contracts/price-oracle/src/finality.rs
@@ -95,7 +95,7 @@ pub fn get_ledger_hash(env: &Env, ledger: u32) -> Option<BytesN<32>> {
 /// recorded at aggregation time with the current ledger hash if `suspect_ledger ==
 /// current_ledger`.  For past ledgers, reorg detection is signalled externally via
 /// `retract_price` (admin-triggered).
-pub fn check_reorg(env: &Env, asset: Address, suspect_ledger: u32) -> bool {
+pub fn check_reorg(env: &Env, _asset: Address, suspect_ledger: u32) -> bool {
     let stored_hash: Option<BytesN<32>> = get_ledger_hash(env, suspect_ledger);
     let current_ledger = env.ledger().sequence();
 
@@ -146,7 +146,7 @@ pub fn mark_price_pending(env: &Env, asset: &Address, aggregate: &AggregatePrice
     // When the SDK exposes env.ledger().hash() this line becomes:
     //   let lhash = env.ledger().hash();
     let seq_bytes = soroban_sdk::Bytes::from_slice(env, &current_ledger.to_le_bytes());
-    let lhash: BytesN<32> = env.crypto().sha256(&seq_bytes);
+    let lhash: BytesN<32> = env.crypto().sha256(&seq_bytes).into();
     record_ledger_hash(env, current_ledger, lhash.clone());
 
     let entry = PendingFinalityEntry {
@@ -346,11 +346,7 @@ pub fn retract_price(env: &Env, asset: Address, committed_ledger: u32) {
 /// # Errors
 /// - `NoData` if no finalized price exists.
 /// - `InsufficientFinality` if the finalized price is too new for `min_finality`.
-pub fn get_finalized_price(
-    env: &Env,
-    asset: Address,
-    min_finality: u32,
-) -> FinalizedPrice {
+pub fn get_finalized_price(env: &Env, asset: Address, min_finality: u32) -> FinalizedPrice {
     let fin_key = DataKey::FinalizedPrice(asset.clone());
     let finalized: FinalizedPrice = env
         .storage()

--- a/contracts/price-oracle/src/heartbeat_tests.rs
+++ b/contracts/price-oracle/src/heartbeat_tests.rs
@@ -149,7 +149,10 @@ fn test_source_becomes_inactive_after_3_misses() {
     let is_inactive = client.is_source_inactive(&source);
     assert!(is_inactive);
     assert_eq!(client.get_missed_heartbeats(&source), 3u32);
-    assert_eq!(client.get_source_health(&source), SourceHealthStatus::Inactive);
+    assert_eq!(
+        client.get_source_health(&source),
+        SourceHealthStatus::Inactive
+    );
 }
 
 #[test]
@@ -175,13 +178,19 @@ fn test_reactivation_requires_heartbeat_and_price() {
     client.is_source_inactive(&source);
     advance_time(&e, 40, 400);
     client.is_source_inactive(&source);
-    assert_eq!(client.get_source_health(&source), SourceHealthStatus::Inactive);
+    assert_eq!(
+        client.get_source_health(&source),
+        SourceHealthStatus::Inactive
+    );
 
     // Heartbeat alone should NOT reactivate (price not yet submitted after reactivation attempt)
     advance_time(&e, 50, 500);
     client.submit_heartbeat(&source);
     // Still inactive because price hasn't been submitted
-    assert_eq!(client.get_source_health(&source), SourceHealthStatus::Inactive);
+    assert_eq!(
+        client.get_source_health(&source),
+        SourceHealthStatus::Inactive
+    );
 
     // Now submit a price in the same ledger window
     client.submit_price(&source, &asset, &1000i128, &500u64);
@@ -189,7 +198,10 @@ fn test_reactivation_requires_heartbeat_and_price() {
     // Now submit another heartbeat — both conditions met, should reactivate
     advance_time(&e, 51, 510);
     client.submit_heartbeat(&source);
-    assert_eq!(client.get_source_health(&source), SourceHealthStatus::Healthy);
+    assert_eq!(
+        client.get_source_health(&source),
+        SourceHealthStatus::Healthy
+    );
     assert_eq!(client.get_missed_heartbeats(&source), 0u32);
 }
 
@@ -212,12 +224,18 @@ fn test_heartbeat_alone_does_not_reactivate() {
     client.is_source_inactive(&source);
     advance_time(&e, 40, 400);
     client.is_source_inactive(&source);
-    assert_eq!(client.get_source_health(&source), SourceHealthStatus::Inactive);
+    assert_eq!(
+        client.get_source_health(&source),
+        SourceHealthStatus::Inactive
+    );
 
     // Heartbeat-only does not reactivate
     advance_time(&e, 50, 500);
     client.submit_heartbeat(&source);
-    assert_eq!(client.get_source_health(&source), SourceHealthStatus::Inactive);
+    assert_eq!(
+        client.get_source_health(&source),
+        SourceHealthStatus::Inactive
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -1,4 +1,10 @@
 #![no_std]
+// The reputation/staking (#171), correlation (#172), tiered whitelisting (#173), and
+// alert-subscription (#174) modules compile and are fully implemented, but a previous
+// botched merge dropped their `#[contractimpl]` wiring in this file, so none of their
+// public functions are reachable from the deployed contract yet. Silencing dead_code
+// here until that wiring lands, rather than deleting working, tested implementations.
+#![allow(dead_code)]
 
 mod admin;
 mod alerts;
@@ -35,13 +41,15 @@ mod prop_tests;
 mod string_boundary_tests;
 
 pub use types::{
-    AggregatePrice, AggregationMethod, Asset, BatchOperation, DataKey, ErrorCode,
-    FinalityStatus, FinalizedPrice, OracleSources, PendingBatch, PendingFinalityEntry,
-    PriceCommit, PriceData, PriceEntry, PriceHistoryEntry, PriceOverrideEntry,
-    SourceHealthStatus, SubscriptionPlans,
+    AggregatePrice, AggregationMethod, Asset, BatchOperation, CrossReferenceResult, DataKey,
+    ErrorCode, FinalityStatus, FinalizedPrice, HealthReport, MigrationState, OracleSources,
+    PendingBatch, PendingFinalityEntry, PriceCommit, PriceData, PriceEntry, PriceHistoryEntry,
+    PriceOverrideEntry, RelayerInfo, SourceHealthStatus, SubscriptionPlans,
 };
 
-use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, Map, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, Address, Env, Map, String, Symbol, Vec,
+};
 
 use crate::storage::read_registered_assets;
 
@@ -622,6 +630,46 @@ impl PriceOracleContract {
         reentrancy::exit(&env);
     }
 
+    /// Sets the maximum number of oracle sources that may be registered. `0` = unlimited.
+    pub fn set_max_sources(env: Env, new_max: u32) {
+        admin::set_max_sources(&env, new_max);
+    }
+
+    /// Returns the current maximum registered-source cap. Defaults to `0` (unlimited).
+    pub fn get_max_sources(env: Env) -> u32 {
+        admin::get_max_sources(&env)
+    }
+
+    /// Sets the maximum number of price history entries retained per asset (issue #94).
+    pub fn set_max_history_per_asset(env: Env, new_max: u32) {
+        admin::set_max_history_per_asset(&env, new_max);
+    }
+
+    /// Returns the current per-asset history cap. Defaults to `1000`.
+    pub fn get_max_history_per_asset(env: Env) -> u32 {
+        admin::get_max_history_per_asset(&env)
+    }
+
+    /// Sets the maximum number of events emitted per aggregation call (issue #92).
+    pub fn set_max_events_per_call(env: Env, new_max: u32) {
+        admin::set_max_events_per_call(&env, new_max);
+    }
+
+    /// Returns the current per-call event cap. Defaults to `20`.
+    pub fn get_max_events_per_call(env: Env) -> u32 {
+        admin::get_max_events_per_call(&env)
+    }
+
+    /// Sets the maximum number of sources used per aggregation; `0` = no limit (issue #93).
+    pub fn set_max_aggregation_sources(env: Env, new_max: u32) {
+        admin::set_max_aggregation_sources(&env, new_max);
+    }
+
+    /// Returns the current maximum aggregation-sources limit. Defaults to `0` (no limit).
+    pub fn get_max_aggregation_sources(env: Env) -> u32 {
+        admin::get_max_aggregation_sources(&env)
+    }
+
     /// Removes an oracle source from the authorized set.
     ///
     /// The admin must authorize this call. Existing price submissions from the source
@@ -798,7 +846,6 @@ impl PriceOracleContract {
     ///
     /// The admin must authorize this call. An asset cannot receive prices until it is
     /// registered.
-
     ///
     /// # Arguments
     ///
@@ -1666,8 +1713,8 @@ impl PriceOracleContract {
     ///
     /// * [`ErrorCode::NotAuthorized`] — if the caller is not the current admin.
     /// * [`ErrorCode::InvalidConfiguration`] — if `threshold_bps > 100_000`.
-    pub fn set_cross_ref_deviation_threshold(env: Env, threshold_bps: u32) {
-        cross_reference::set_cross_ref_deviation_threshold(&env, threshold_bps);
+    pub fn set_cross_ref_deviation_bps(env: Env, threshold_bps: u32) {
+        cross_reference::set_cross_ref_deviation_bps(&env, threshold_bps);
     }
 
     /// Returns the current cross-reference deviation threshold in basis points.
@@ -1679,77 +1726,8 @@ impl PriceOracleContract {
     /// # Returns
     ///
     /// Threshold in basis points. Defaults to `500` (5 %).
-    pub fn get_cross_ref_deviation_threshold(env: Env) -> u32 {
-        cross_reference::get_cross_ref_deviation_threshold(&env)
-    }
-
-    // --- Cross-Reference Oracle ---
-
-    /// Registers an external oracle as a cross-reference source for price verification.
-    ///
-    /// `asset_mapping` maps each of our asset `Address` values to the equivalent asset
-    /// `Address` accepted by the external oracle's `lastprice` function. Calling
-    /// [`get_cross_reference`](Self::get_cross_reference) will invoke this oracle when
-    /// a mapping exists for the queried asset.
-    ///
-    /// # Errors
-    ///
-    /// * [`ErrorCode::NotAuthorized`] — if the caller is not the current admin.
-    pub fn add_reference_oracle(
-        env: Env,
-        contract_id: Address,
-        asset_mapping: Map<Address, Address>,
-    ) {
-        cross_reference::add_reference_oracle(&env, contract_id, asset_mapping);
-    }
-
-    /// Removes a previously registered reference oracle.
-    ///
-    /// # Errors
-    ///
-    /// * [`ErrorCode::NotAuthorized`] — if the caller is not the current admin.
-    pub fn remove_reference_oracle(env: Env, contract_id: Address) {
-        cross_reference::remove_reference_oracle(&env, contract_id);
-    }
-
-    /// Returns the ordered list of registered reference oracle contract addresses.
-    pub fn get_reference_oracles(env: Env) -> Vec<Address> {
-        cross_reference::get_reference_oracles(&env)
-    }
-
-    /// Queries our aggregated price for `asset` against the first registered reference
-    /// oracle that has a mapping for it.
-    ///
-    /// Calls `lastprice(mapped_asset)` on the reference oracle via cross-contract
-    /// invocation. Returns `None` when no local aggregate exists, no oracle has a
-    /// mapping for `asset`, or every oracle returned `0`.
-    ///
-    /// Emits [`CrossRefDeviationEvent`](crate::events::CrossRefDeviationEvent) when
-    /// the computed deviation exceeds the configured threshold.
-    pub fn get_cross_reference(env: Env, asset: Address) -> Option<CrossReferenceResult> {
-        cross_reference::get_cross_reference(&env, asset)
-    }
-
-    /// Sets the maximum acceptable price deviation between our oracle and a reference
-    /// oracle, expressed in basis points (100 bps = 1 %).
-    ///
-    /// When the deviation for a given asset exceeds this threshold a
-    /// [`CrossRefDeviationEvent`](crate::events::CrossRefDeviationEvent) is emitted.
-    /// Defaults to `500` (5 %). Values above `100_000` are rejected.
-    ///
-    /// # Errors
-    ///
-    /// * [`ErrorCode::NotAuthorized`] — if the caller is not the current admin.
-    /// * [`ErrorCode::InvalidConfiguration`] — if `threshold_bps > 100_000`.
-    pub fn set_cross_ref_deviation_threshold(env: Env, threshold_bps: u32) {
-        cross_reference::set_cross_ref_deviation_threshold(&env, threshold_bps);
-    }
-
-    /// Returns the current cross-reference deviation threshold in basis points.
-    ///
-    /// Defaults to `500` (5 %) when no value has been configured.
-    pub fn get_cross_ref_deviation_threshold(env: Env) -> u32 {
-        cross_reference::get_cross_ref_deviation_threshold(&env)
+    pub fn get_cross_ref_deviation_bps(env: Env) -> u32 {
+        cross_reference::get_cross_ref_deviation_bps(&env)
     }
 
     // =========================================================================
@@ -1770,7 +1748,7 @@ impl PriceOracleContract {
 
     /// Returns the number of consecutive missed heartbeats for a source.
     pub fn get_missed_heartbeats(env: Env, source: Address) -> u32 {
-        sources::get_missed_heartbeats(&env, source)
+        sources::get_missed_heartbeats(&env, &source)
     }
 
     /// Returns the ledger sequence number of the most recent price submission from a source.
@@ -1851,12 +1829,7 @@ impl PriceOracleContract {
     /// * [`ErrorCode::AssetNotRegistered`] — asset is not registered.
     /// * [`ErrorCode::AlreadyCommitted`] — source already committed this round.
     /// * [`ErrorCode::RevealWindowClosed`] — called after commit window closed.
-    pub fn commit_price(
-        env: Env,
-        source: Address,
-        asset: Address,
-        hash: soroban_sdk::BytesN<32>,
-    ) {
+    pub fn commit_price(env: Env, source: Address, asset: Address, hash: soroban_sdk::BytesN<32>) {
         reentrancy::enter(&env);
         prices::commit_price(&env, source, asset, hash);
         reentrancy::exit(&env);

--- a/contracts/price-oracle/src/migration.rs
+++ b/contracts/price-oracle/src/migration.rs
@@ -21,11 +21,11 @@
 //! 3. Implement the data-transformation logic.
 //! 4. Add tests in `migration_tests` below.
 
-use soroban_sdk::{panic_with_error, Address, Env};
+use soroban_sdk::{Address, Env};
 
 use crate::events::{MigrationCompletedEvent, MigrationResumedEvent, MigrationStartedEvent};
-use crate::storage::{get_admin, read_registered_assets, read_oracle_sources, LEDGER_BUMP, LEDGER_THRESHOLD};
-use crate::types::{DataKey, ErrorCode, MigrationState, MigrationStatus};
+use crate::storage::{get_admin, read_registered_assets, LEDGER_BUMP, LEDGER_THRESHOLD};
+use crate::types::{DataKey, MigrationState, MigrationStatus};
 
 /// The storage schema version that this build of the contract targets.
 /// Increment this when releasing a schema-changing upgrade.
@@ -51,9 +51,7 @@ pub fn get_storage_version(env: &Env) -> u32 {
 
 /// Returns the active [`MigrationState`], or `None` when no migration is running.
 pub fn get_migration_state(env: &Env) -> Option<MigrationState> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::MigrationState)
+    env.storage().persistent().get(&DataKey::MigrationState)
 }
 
 /// Starts or resumes a storage migration.
@@ -77,7 +75,11 @@ pub fn migrate_storage(env: &Env, batch_size: u32) {
     let admin: Address = get_admin(env);
     admin.require_auth();
 
-    let effective_batch = if batch_size == 0 { DEFAULT_BATCH_SIZE } else { batch_size };
+    let effective_batch = if batch_size == 0 {
+        DEFAULT_BATCH_SIZE
+    } else {
+        batch_size
+    };
 
     let state_opt = get_migration_state(env);
 
@@ -132,9 +134,7 @@ pub fn migrate_storage(env: &Env, batch_size: u32) {
         env.storage()
             .persistent()
             .set(&DataKey::StorageVersion, &state.to_version);
-        env.storage()
-            .persistent()
-            .remove(&DataKey::MigrationState);
+        env.storage().persistent().remove(&DataKey::MigrationState);
 
         MigrationCompletedEvent {
             admin,

--- a/contracts/price-oracle/src/pause.rs
+++ b/contracts/price-oracle/src/pause.rs
@@ -8,7 +8,9 @@ pub fn pause(env: &Env) {
     let admin = get_admin(env);
     admin.require_auth();
 
-    env.storage().persistent().set(&DataKey::CfgPauseFlag, &true);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CfgPauseFlag, &true);
 
     ContractPausedEvent {
         admin: admin.clone(),
@@ -21,7 +23,9 @@ pub fn unpause(env: &Env) {
     let admin = get_admin(env);
     admin.require_auth();
 
-    env.storage().persistent().set(&DataKey::CfgPauseFlag, &false);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CfgPauseFlag, &false);
 
     ContractUnpausedEvent {
         admin: admin.clone(),

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -2,19 +2,20 @@ use soroban_sdk::{panic_with_error, Address, Env, String, Vec};
 
 use crate::admin::{
     get_aggregation_cooldown, get_aggregation_method, get_asset_resolution, get_decimals,
-    get_max_history_length, get_min_sources_required, get_min_submission_interval,
+    get_max_aggregation_sources, get_max_events_per_call, get_max_history_length,
+    get_max_history_per_asset, get_min_sources_required, get_min_submission_interval,
     get_timestamp_threshold,
 };
 use crate::events::{
-    AggregationTriggeredEvent, HistoryPrunedEvent, PriceAggregatedEvent, PriceOverrideExpiredEvent,
-    PriceOverrideRemovedEvent, PriceOverrideSetEvent, PriceStaleEvent, PriceSubmittedEvent,
-    RateLimitExceededEvent, SourceNonCompliantEvent, SourcesInsufficientEvent,
+    AggregationTriggeredEvent, EventLimitWarningEvent, HistoryPerAssetPrunedEvent,
+    HistoryPrunedEvent, PriceAggregatedEvent, PriceOverrideExpiredEvent, PriceOverrideRemovedEvent,
+    PriceOverrideSetEvent, PriceStaleEvent, PriceSubmittedEvent, RateLimitExceededEvent,
+    SourceNonCompliantEvent, SourcesInsufficientEvent,
 };
 use crate::pause::check_not_paused;
 use crate::storage::{
     check_registered_asset, check_source, compute_mean, compute_median, compute_trimmed_mean,
     get_admin, is_subscribed, read_oracle_sources, LEDGER_BUMP, LEDGER_THRESHOLD,
-    check_rate_limit, increment_query_count,
 };
 use crate::types::{
     AggregatePrice, Asset, DataKey, ErrorCode, OracleSources, PriceData, PriceEntry,
@@ -49,8 +50,6 @@ pub fn submit_prices(env: &Env, source: Address, asset_prices: Vec<(Address, i12
     let ledger_time = env.ledger().timestamp();
     let threshold = get_timestamp_threshold(env);
     let current_ledger = env.ledger().sequence();
-
-    let mut event_count: u32 = 0;
 
     // Validate all entries first for atomicity — any invalid entry aborts the whole call.
     for i in 0..asset_prices.len() {
@@ -108,23 +107,23 @@ pub fn submit_prices(env: &Env, source: Address, asset_prices: Vec<(Address, i12
             timestamp,
         }
         .publish(env);
-        event_count += 1;
     }
 
     // Trigger aggregation for each submitted asset.
     for i in 0..asset_prices.len() {
         let (asset, _, _) = asset_prices.get_unchecked(i);
-        aggregate_asset(env, asset, current_ledger, decimals);
+        aggregate_asset(env, &asset, current_ledger, decimals);
     }
 }
 
 /// Internal helper: re-aggregate all sources for a single asset and write history.
 fn aggregate_asset(env: &Env, asset: &Address, current_ledger: u32, decimals: u32) {
+    let max_events = get_max_events_per_call(env);
+    let mut event_count: u32 = 0;
+
     let min_required = get_min_sources_required(env);
     let oracle_sources: OracleSources = read_oracle_sources(env);
     let total_sources = oracle_sources.sources.len();
-    let decimals = get_decimals(env);
-    let current_ledger = env.ledger().sequence();
 
     // Issue #93: if MaxAggregationSources > 0 and we have more sources than the cap,
     // randomly select a subset using the current ledger hash for determinism.
@@ -166,9 +165,10 @@ fn aggregate_asset(env: &Env, asset: &Address, current_ledger: u32, decimals: u3
 
     let min_interval = get_min_submission_interval(env);
     let current_ledger_for_agg = env.ledger().sequence();
+    let selected_count = selected_sources.len();
 
-    for i in 0..total_sources {
-        let src = oracle_sources.sources.get_unchecked(i);
+    for i in 0..selected_count {
+        let src = selected_sources.get_unchecked(i);
 
         // #70: enforce min submission interval compliance
         if min_interval > 0 {
@@ -347,23 +347,28 @@ fn aggregate_asset(env: &Env, asset: &Address, current_ledger: u32, decimals: u3
             }
             .publish(env);
         }
-    } else {
-        if event_count < max_events {
-            SourcesInsufficientEvent {
-                asset: asset.clone(),
-                current_source_count: contributing_sources,
-                min_sources_required: min_required,
-            }
-            .publish(env);
-        } else {
-            EventLimitWarningEvent {
-                asset: asset.clone(),
-                event_count,
-                max_events,
-            }
-            .publish(env);
+    } else if event_count < max_events {
+        SourcesInsufficientEvent {
+            asset: asset.clone(),
+            current_source_count: contributing_sources,
+            min_sources_required: min_required,
         }
+        .publish(env);
+    } else {
+        EventLimitWarningEvent {
+            asset: asset.clone(),
+            event_count,
+            max_events,
+        }
+        .publish(env);
     }
+}
+
+/// Re-runs aggregation for `asset`, shared by the direct and relayed submission paths.
+pub(crate) fn do_aggregate(env: &Env, asset: &Address) {
+    let decimals = get_decimals(env);
+    let current_ledger = env.ledger().sequence();
+    aggregate_asset(env, asset, current_ledger, decimals);
 }
 
 pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, timestamp: u64) {
@@ -473,11 +478,7 @@ pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePri
     let result: AggregatePrice = env.storage().persistent().get(&key)?;
 
     // max_age gating (if enabled)
-    if max_age > 0 && result
-        .timestamp
-        .saturating_add(max_age)
-        < ledger_time
-    {
+    if max_age > 0 && result.timestamp.saturating_add(max_age) < ledger_time {
         PriceStaleEvent {
             asset: asset.clone(),
             last_update_ledger: 0,
@@ -489,11 +490,7 @@ pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePri
 
     // resolution gating (if enabled)
     let resolution = get_asset_resolution(env, asset.clone());
-    if resolution > 0 && result
-        .timestamp
-        .saturating_add(resolution as u64)
-        < ledger_time
-    {
+    if resolution > 0 && result.timestamp.saturating_add(resolution as u64) < ledger_time {
         PriceStaleEvent {
             asset: asset.clone(),
             last_update_ledger: 0,
@@ -508,7 +505,6 @@ pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePri
         .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
     Some(result)
 }
-
 
 pub fn get_source_price(env: &Env, asset: Address, source: Address) -> PriceEntry {
     check_registered_asset(env, &asset);
@@ -535,6 +531,8 @@ pub fn get_all_prices(env: &Env, asset: Address) -> Vec<PriceEntry> {
     prices
 }
 
+/// Not currently wired into `get_price` — kept for a future rate-limiting pass.
+#[allow(dead_code)]
 pub fn check_rate_limit_and_increment(env: &Env, consumer: &Address) {
     if is_subscribed(env, consumer) {
         return;
@@ -542,7 +540,11 @@ pub fn check_rate_limit_and_increment(env: &Env, consumer: &Address) {
 
     let ledger = env.ledger().sequence();
     let rate_limit_key = DataKey::QueryRateLimit;
-    let max_queries: u32 = env.storage().persistent().get(&rate_limit_key).unwrap_or(100);
+    let max_queries: u32 = env
+        .storage()
+        .persistent()
+        .get(&rate_limit_key)
+        .unwrap_or(100);
 
     let count_key = DataKey::QueryCount(consumer.clone(), ledger);
     let current_count: u32 = env.storage().temporary().get(&count_key).unwrap_or(0);
@@ -559,7 +561,9 @@ pub fn check_rate_limit_and_increment(env: &Env, consumer: &Address) {
 
     let new_count = current_count + 1;
     env.storage().temporary().set(&count_key, &new_count);
-    env.storage().temporary().extend_ttl(&count_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    env.storage()
+        .temporary()
+        .extend_ttl(&count_key, LEDGER_THRESHOLD, LEDGER_BUMP);
 }
 
 pub fn lastprice(env: &Env, asset: Asset) -> Option<PriceData> {
@@ -771,6 +775,8 @@ pub fn get_price_override(env: &Env, asset: Address) -> Option<PriceOverrideEntr
     env.storage().persistent().get(&override_key)
 }
 
+/// Not currently wired into any public contract endpoint.
+#[allow(dead_code)]
 pub fn historical_price_change_percent(
     env: &Env,
     asset: Address,
@@ -1006,12 +1012,7 @@ pub fn current_round_ledger(env: &Env) -> u32 {
 /// - `AssetNotRegistered` — asset is not registered.
 /// - `AlreadyCommitted` — source already committed this round for this asset.
 /// - `RevealWindowClosed` — called outside the commit window for this round.
-pub fn commit_price(
-    env: &Env,
-    source: Address,
-    asset: Address,
-    hash: soroban_sdk::BytesN<32>,
-) {
+pub fn commit_price(env: &Env, source: Address, asset: Address, hash: soroban_sdk::BytesN<32>) {
     check_not_paused(env);
     source.require_auth();
     check_source(env, &source);
@@ -1046,9 +1047,7 @@ pub fn commit_price(
     // preventing griefing through permanent storage bloat.
     let ttl = commit_window + get_reveal_window(env) + 1;
     env.storage().temporary().set(&commit_key, &commit);
-    env.storage()
-        .temporary()
-        .extend_ttl(&commit_key, ttl, ttl);
+    env.storage().temporary().extend_ttl(&commit_key, ttl, ttl);
 
     crate::events::PriceCommittedEvent {
         asset,
@@ -1258,5 +1257,5 @@ fn _compute_commit_hash(
         preimage.push_back(*b);
     }
 
-    env.crypto().sha256(&preimage)
+    env.crypto().sha256(&preimage).into()
 }

--- a/contracts/price-oracle/src/quota_tests.rs
+++ b/contracts/price-oracle/src/quota_tests.rs
@@ -68,7 +68,7 @@ fn test_submissions_within_quota() {
 
     // Submit 5 prices (at quota limit)
     for i in 0..5 {
-        submit_test_price(&client, &source, &asset, 100i128 + i as i128, 1234567890 + i as u64, i as u64 + 1);
+        submit_test_price(&client, &source, &asset, 100i128 + i as i128, 1234567890 + i as u64);
     }
 
     // Verify all submissions were successful
@@ -91,7 +91,7 @@ fn test_submissions_exceed_quota() {
 
     // Try to submit 4 prices (exceeds quota of 3)
     for i in 0..4 {
-        submit_test_price(&client, &source, &asset, 100i128 + i as i128, 1234567890 + i as u64, i as u64 + 1);
+        submit_test_price(&client, &source, &asset, 100i128 + i as i128, 1234567890 + i as u64);
     }
 }
 
@@ -107,13 +107,13 @@ fn test_quota_reset_after_period() {
 
     // Submit at ledger 100
     ledger_default(&e, 100, 1234567890);
-    submit_test_price(&client, &source, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source, &asset, 110i128, 1234567890, 2);
+    submit_test_price(&client, &source, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source, &asset, 110i128, 1234567890);
 
     // At ledger 200, quota period has elapsed, quota resets
     ledger_default(&e, 200, 1234567891);
-    submit_test_price(&client, &source, &asset, 120i128, 1234567891, 3);
-    submit_test_price(&client, &source, &asset, 130i128, 1234567891, 4);
+    submit_test_price(&client, &source, &asset, 120i128, 1234567891);
+    submit_test_price(&client, &source, &asset, 130i128, 1234567891);
 
     // All 4 submissions should succeed
     let all_prices = client.get_all_prices(&asset);
@@ -134,7 +134,7 @@ fn test_quota_boundary_exact_at_end() {
 
     // Submit exactly 3
     for i in 0..3 {
-        submit_test_price(&client, &source, &asset, 100i128 + i as i128, 1234567890 + i as u64, i as u64 + 1);
+        submit_test_price(&client, &source, &asset, 100i128 + i as i128, 1234567890 + i as u64);
     }
 
     // Verify 3 were accepted
@@ -157,12 +157,12 @@ fn test_multiple_sources_independent_quotas() {
     ledger_default(&e, 100, 1234567890);
 
     // source1 submits 2
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source1, &asset, 110i128, 1234567890, 2);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source1, &asset, 110i128, 1234567890);
 
     // source2 submits 5
     for i in 0..5 {
-        submit_test_price(&client, &source2, &asset, 200i128 + i as i128, 1234567890 + i as u64, i as u64 + 1);
+        submit_test_price(&client, &source2, &asset, 200i128 + i as i128, 1234567890 + i as u64);
     }
 
     let all_prices = client.get_all_prices(&asset);
@@ -183,7 +183,7 @@ fn test_zero_quota_treated_as_unlimited() {
 
     // Submit many more than would fit in a typical quota
     for i in 0..20 {
-        submit_test_price(&client, &source, &asset, 100i128 + i as i128, 1234567890 + i as u64, i as u64 + 1);
+        submit_test_price(&client, &source, &asset, 100i128 + i as i128, 1234567890 + i as u64);
     }
 
     let all_prices = client.get_all_prices(&asset);
@@ -203,9 +203,9 @@ fn test_quota_exceeded_at_first_submission_over_limit() {
 
     ledger_default(&e, 100, 1234567890);
 
-    submit_test_price(&client, &source, &asset, 100i128, 1234567890, 1);
+    submit_test_price(&client, &source, &asset, 100i128, 1234567890);
     // Second submission should fail
-    submit_test_price(&client, &source, &asset, 110i128, 1234567890, 2);
+    submit_test_price(&client, &source, &asset, 110i128, 1234567890);
 }
 
 #[test]

--- a/contracts/price-oracle/src/relayer.rs
+++ b/contracts/price-oracle/src/relayer.rs
@@ -2,11 +2,15 @@ use soroban_sdk::{panic_with_error, Address, Env, String};
 
 use crate::admin::{get_decimals, get_timestamp_threshold};
 use crate::assets::get_min_price;
-use crate::events::{emit_relayer_fee_set, PriceRelayedEvent, RelayerAddedEvent, RelayerRemovedEvent};
+use crate::events::{
+    emit_relayer_fee_set, PriceRelayedEvent, RelayerAddedEvent, RelayerRemovedEvent,
+};
 use crate::pause::check_not_paused;
 use crate::prices::do_aggregate;
 use crate::sources::{is_source_suspended, record_invalid_submission};
-use crate::storage::{check_registered_asset, check_source, get_admin, LEDGER_BUMP, LEDGER_THRESHOLD};
+use crate::storage::{
+    check_registered_asset, check_source, get_admin, LEDGER_BUMP, LEDGER_THRESHOLD,
+};
 use crate::types::{DataKey, ErrorCode, PriceEntry, RelayerInfo};
 
 // ---------------------------------------------------------------------------
@@ -202,6 +206,7 @@ pub fn submit_price_relayed(
         source: source.clone(),
         decimals,
         last_updated: current_ledger,
+        ledger_timestamp: env.ledger().timestamp(),
     };
     env.storage()
         .persistent()
@@ -222,11 +227,7 @@ pub fn submit_price_relayed(
 
     // Track relayer metrics: submission count and accrued fee balance.
     let count_key = DataKey::RelayerSubmissionCount(relayer.clone());
-    let count: u64 = env
-        .storage()
-        .persistent()
-        .get(&count_key)
-        .unwrap_or(0u64);
+    let count: u64 = env.storage().persistent().get(&count_key).unwrap_or(0u64);
     env.storage()
         .persistent()
         .set(&count_key, &count.saturating_add(1));
@@ -286,17 +287,11 @@ pub fn get_relayer_fee_per_submission(env: &Env) -> i128 {
 /// Returns the total accumulated fee balance (in stroops) owed to `relayer`.
 pub fn get_relayer_fee_balance(env: &Env, relayer: Address) -> i128 {
     let key = DataKey::RelayerFeeBalance(relayer);
-    env.storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or(0i128)
+    env.storage().persistent().get(&key).unwrap_or(0i128)
 }
 
 /// Returns the total number of successful relayed submissions made by `relayer`.
 pub fn get_relayer_submission_count(env: &Env, relayer: Address) -> u64 {
     let key = DataKey::RelayerSubmissionCount(relayer);
-    env.storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or(0u64)
+    env.storage().persistent().get(&key).unwrap_or(0u64)
 }

--- a/contracts/price-oracle/src/sources.rs
+++ b/contracts/price-oracle/src/sources.rs
@@ -2,8 +2,8 @@ use soroban_sdk::{panic_with_error, symbol_short, Address, Bytes, Env, String, V
 
 use crate::events::{
     emit_admin_action, RemovalCooldownChangedEvent, SourceActiveAgainEvent, SourceAddedEvent,
-    SourceHeartbeatEvent, SourceInactiveEvent, SourceRemovedEvent, SourceMarkedForRemovalEvent,
-    SourceRemovalCancelledEvent,
+    SourceHeartbeatEvent, SourceInactiveEvent, SourceMarkedForRemovalEvent,
+    SourceRemovalCancelledEvent, SourceRemovedEvent,
 };
 use crate::storage::{
     get_admin, is_source_inactive as check_source_inactive, mark_source_active,
@@ -32,7 +32,7 @@ pub fn add_source(env: &Env, source: Address, name: String) {
 
     let oracle_sources: OracleSources = read_oracle_sources(env);
     let max_sources = crate::admin::get_max_sources(env);
-    if oracle_sources.sources.len() >= max_sources {
+    if max_sources > 0 && oracle_sources.sources.len() >= max_sources {
         panic_with_error!(env, ErrorCode::MaxSourcesReached);
     }
 
@@ -129,7 +129,7 @@ pub fn submit_heartbeat(env: &Env, source: Address) {
         // Reactivation requires BOTH a heartbeat AND a price submission in the same or
         // adjacent ledger. Check whether the source has submitted a price after the last
         // reactivation attempt.
-        let price_submitted_key = DataKey::SrcPriceSubmittedAfterReactivation(source.clone());
+        let price_submitted_key = DataKey::SrcPriceSubmitAfterReactivation(source.clone());
         let has_price: bool = env
             .storage()
             .persistent()
@@ -178,9 +178,10 @@ pub fn submit_heartbeat(env: &Env, source: Address) {
     }
 
     // Update the last-heartbeat ledger for adaptive interval computation.
-    env.storage()
-        .persistent()
-        .set(&DataKey::SrcLastPriceLedger(source.clone()), &current_ledger);
+    env.storage().persistent().set(
+        &DataKey::SrcLastPriceLedger(source.clone()),
+        &current_ledger,
+    );
 
     SourceHeartbeatEvent {
         source: source.clone(),
@@ -214,7 +215,11 @@ pub fn is_source_inactive(env: &Env, source: Address) -> bool {
 
             if new_missed >= MISS_THRESHOLD {
                 // Cross the inactivity threshold.
-                let old_status = if new_missed == MISS_THRESHOLD { 1u32 } else { 2u32 };
+                let old_status = if new_missed == MISS_THRESHOLD {
+                    1u32
+                } else {
+                    2u32
+                };
                 mark_source_inactive(env, &source);
 
                 // Record when inactivity started (only on first trip).
@@ -439,7 +444,15 @@ pub fn get_source_reputation(env: &Env, source: Address) -> i128 {
 /// Called after aggregation to update a source's reputation based on deviation from median.
 /// `source_price`: the price submitted by this source
 /// `median_price`: the aggregated median for the asset
-pub fn update_source_reputation(env: &Env, source: &Address, source_price: i128, median_price: i128) {
+///
+/// Not currently wired into `aggregate_asset` — kept for a future reputation-scoring pass.
+#[allow(dead_code)]
+pub fn update_source_reputation(
+    env: &Env,
+    source: &Address,
+    source_price: i128,
+    median_price: i128,
+) {
     if median_price == 0 {
         return;
     }
@@ -496,7 +509,7 @@ pub fn set_max_inactive_ledgers(env: &Env, ledgers: u32) {
     env.storage()
         .persistent()
         .set(&DataKey::CfgMaxInactiveLedgers, &ledgers);
-    crate::events::MaxInactiveLedgersChangedEvent { value: ledgers }.publish(env);
+    crate::events::InactiveLedgersChangedEvent { value: ledgers }.publish(env);
 }
 
 /// Returns the configured max-inactive-ledgers threshold (default 64).
@@ -618,7 +631,7 @@ pub fn record_price_submitted(env: &Env, source: &Address, ledger: u32) {
         .set(&DataKey::SrcLastPriceLedger(source.clone()), &ledger);
     // Mark that a price has been submitted after the most recent reactivation.
     env.storage().persistent().set(
-        &DataKey::SrcPriceSubmittedAfterReactivation(source.clone()),
+        &DataKey::SrcPriceSubmitAfterReactivation(source.clone()),
         &true,
     );
 }
@@ -755,5 +768,5 @@ fn _remove_source_internal(env: &Env, source: Address) {
         .remove(&DataKey::SrcLastPriceLedger(source.clone()));
     env.storage()
         .persistent()
-        .remove(&DataKey::SrcPriceSubmittedAfterReactivation(source));
+        .remove(&DataKey::SrcPriceSubmitAfterReactivation(source));
 }

--- a/contracts/price-oracle/src/staking_tests.rs
+++ b/contracts/price-oracle/src/staking_tests.rs
@@ -170,8 +170,8 @@ fn test_source_excluded_below_minimum() {
     client.stake(&source1, &2000i128);
     // source2 has no stake, below minimum
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     // Only source1 should be included in aggregation (source2 excluded)
     assert!(client.get_price(&asset, &0u64).is_none());
@@ -193,8 +193,8 @@ fn test_stake_allows_submission() {
     client.stake(&source1, &2000i128);
     client.stake(&source2, &2000i128);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 150i128);

--- a/contracts/price-oracle/src/storage.rs
+++ b/contracts/price-oracle/src/storage.rs
@@ -211,22 +211,32 @@ pub fn mark_source_active(env: &Env, source: &Address) {
     env.storage().persistent().remove(&key);
 }
 
+/// Not currently wired into `get_price` — kept for a future rate-limiting pass.
+#[allow(dead_code)]
 pub fn check_rate_limit(env: &Env, consumer: &Address) -> bool {
     let ledger = env.ledger().sequence();
     let key = DataKey::QueryCount(consumer.clone(), ledger);
     let count: u32 = env.storage().temporary().get(&key).unwrap_or(0);
     let rate_limit_key = DataKey::QueryRateLimit;
-    let max_queries: u32 = env.storage().persistent().get(&rate_limit_key).unwrap_or(DEFAULT_QUERY_RATE_LIMIT);
+    let max_queries: u32 = env
+        .storage()
+        .persistent()
+        .get(&rate_limit_key)
+        .unwrap_or(DEFAULT_QUERY_RATE_LIMIT);
     count < max_queries
 }
 
+/// Not currently wired into `get_price` — kept for a future rate-limiting pass.
+#[allow(dead_code)]
 pub fn increment_query_count(env: &Env, consumer: &Address) -> u32 {
     let ledger = env.ledger().sequence();
     let key = DataKey::QueryCount(consumer.clone(), ledger);
     let count: u32 = env.storage().temporary().get(&key).unwrap_or(0);
     let new_count = count + 1;
     env.storage().temporary().set(&key, &new_count);
-    env.storage().temporary().extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    env.storage()
+        .temporary()
+        .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
     new_count
 }
 
@@ -258,6 +268,8 @@ pub fn get_plan_amount(env: &Env, duration: u32) -> Option<i128> {
     plans.get(duration)
 }
 
+/// Only reachable today via `check_rate_limit_and_increment`, which is itself unwired.
+#[allow(dead_code)]
 pub fn is_subscribed(env: &Env, consumer: &Address) -> bool {
     let key = DataKey::SubscriptionExpiry(consumer.clone());
     let expiry: u64 = env.storage().persistent().get(&key).unwrap_or(0);

--- a/contracts/price-oracle/src/string_boundary_tests.rs
+++ b/contracts/price-oracle/src/string_boundary_tests.rs
@@ -9,8 +9,9 @@ use crate::test_helpers::*;
 
 /// Builds a soroban String of exactly `len` ASCII 'a' characters.
 fn make_string(e: &Env, len: usize) -> String {
-    let s: ::core::string::String = "a".repeat(len);
-    String::from_str(e, &s)
+    let buf = [b'a'; 512];
+    let s = core::str::from_utf8(&buf[..len]).unwrap();
+    String::from_str(e, s)
 }
 
 // ── Description ──────────────────────────────────────────────────────────────

--- a/contracts/price-oracle/src/subscription.rs
+++ b/contracts/price-oracle/src/subscription.rs
@@ -1,43 +1,35 @@
-use soroban_sdk::{panic_with_error, Address, Env, Symbol, Vec};
+use soroban_sdk::{panic_with_error, Address, Env};
 
-use crate::events::{
-    SubscriptionCreatedEvent, SubscriptionRenewedEvent,
-};
+use crate::events::{SubscriptionCreatedEvent, SubscriptionRenewedEvent};
 use crate::storage::{
-    get_plan_amount, is_subscribed, read_subscription_expiry, read_subscription_plans,
-    write_subscription_expiry, LEDGER_BUMP, LEDGER_THRESHOLD,
+    get_plan_amount, read_subscription_expiry, read_subscription_plans, write_subscription_expiry,
+    LEDGER_BUMP, LEDGER_THRESHOLD,
 };
 use crate::types::{DataKey, ErrorCode, SubscriptionPlans};
-
-pub const DEFAULT_SUBSCRIPTION_DURATION: u64 = 86400; // 1 day in seconds
 
 pub fn subscribe(env: &Env, consumer: Address, duration: u32) {
     consumer.require_auth();
 
-    let plan_amount = get_plan_amount(env, duration).unwrap_or_else(|| {
-        panic_with_error!(env, ErrorCode::InvalidDuration)
-    });
+    let _plan_amount = get_plan_amount(env, duration)
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::InvalidDuration));
 
     let ledger_timestamp = env.ledger().timestamp();
     let new_expiry = ledger_timestamp.saturating_add(duration as u64);
 
     write_subscription_expiry(env, &consumer, new_expiry);
 
-    env.events().publish(
-        (Symbol::new(env, "sub_created"), consumer.clone()),
-        SubscriptionCreatedEvent {
-            consumer: consumer.clone(),
-            duration: duration as u64,
-        },
-    );
+    SubscriptionCreatedEvent {
+        consumer: consumer.clone(),
+        duration: duration as u64,
+    }
+    .publish(env);
 }
 
 pub fn renew_subscription(env: &Env, consumer: Address) {
     consumer.require_auth();
 
-    let current_expiry = read_subscription_expiry(env, &consumer).unwrap_or_else(|| {
-        panic_with_error!(env, ErrorCode::NoData)
-    });
+    let current_expiry = read_subscription_expiry(env, &consumer)
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::NoData));
 
     let ledger_timestamp = env.ledger().timestamp();
 
@@ -50,12 +42,10 @@ pub fn renew_subscription(env: &Env, consumer: Address) {
 
     write_subscription_expiry(env, &consumer, new_expiry);
 
-    env.events().publish(
-        (Symbol::new(env, "sub_renewed"), consumer.clone()),
-        SubscriptionRenewedEvent {
-            consumer: consumer.clone(),
-        },
-    );
+    SubscriptionRenewedEvent {
+        consumer: consumer.clone(),
+    }
+    .publish(env);
 }
 
 pub fn get_subscription_expiry(env: &Env, consumer: Address) -> u64 {

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -93,7 +93,7 @@ fn test_admin_functions() {
         String::from_str(&e, "Updated Description")
     );
 
-    assert_eq!(client.get_max_sources(), 50u32);
+    assert_eq!(client.get_max_sources(), 0u32);
     client.set_max_sources(&10u32);
     assert_eq!(client.get_max_sources(), 10u32);
 }
@@ -119,7 +119,7 @@ fn test_max_sources_enforced() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #16)")]
+#[should_panic(expected = "Error(Contract, #23)")]
 fn test_max_sources_enforced_exact_limit() {
     let e = Env::default();
     let (client, _) = setup_contract(&e);
@@ -154,7 +154,7 @@ fn test_register_asset_twice() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #16)")]
+#[should_panic(expected = "Error(Contract, #28)")]
 fn test_register_asset_max_assets_reached() {
     let e = Env::default();
     let (client, _) = setup_contract(&e);
@@ -264,12 +264,12 @@ fn test_submit_price_and_get_price() {
     client.set_min_sources_required(&2u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
 
     // Only one source submitted, min_sources=2 → not aggregated yet → None
     assert!(client.get_price(&asset, &0u64).is_none());
 
-    submit_test_price(&client, &source2, &asset, 110i128, 1234567890, 1);
+    submit_test_price(&client, &source2, &asset, 110i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 105i128);
@@ -290,9 +290,9 @@ fn test_submit_price_median_odd() {
     client.set_min_sources_required(&3u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
-    submit_test_price(&client, &source3, &asset, 300i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
+    submit_test_price(&client, &source3, &asset, 300i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 200i128);
@@ -312,10 +312,10 @@ fn test_submit_price_median_even() {
     client.set_min_sources_required(&4u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
-    submit_test_price(&client, &source3, &asset, 300i128, 1234567890, 1);
-    submit_test_price(&client, &source4, &asset, 400i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
+    submit_test_price(&client, &source3, &asset, 300i128, 1234567890);
+    submit_test_price(&client, &source4, &asset, 400i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 250i128);
@@ -331,7 +331,7 @@ fn test_submit_price_unauthorized_source() {
     let fake_source = Address::generate(&e);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &fake_source, &asset, 100i128, 1234567890, 1);
+    submit_test_price(&client, &fake_source, &asset, 100i128, 1234567890);
 }
 
 #[test]
@@ -343,7 +343,7 @@ fn test_submit_price_invalid_zero() {
     register_test_source(&e, &client, "Band");
     let asset1 = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset1, 0i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset1, 0i128, 1234567890);
 }
 
 #[test]
@@ -355,7 +355,7 @@ fn test_submit_price_invalid_negative() {
     register_test_source(&e, &client, "Band");
     let asset1 = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset1, -100i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset1, -100i128, 1234567890);
 }
 
 #[test]
@@ -366,7 +366,7 @@ fn test_submit_price_unregistered_asset() {
     let source1 = register_test_source(&e, &client, "Chainlink");
 
     let unregistered_asset = Address::generate(&e);
-    submit_test_price(&client, &source1, &unregistered_asset, 100i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &unregistered_asset, 100i128, 1234567890);
 }
 
 #[test]
@@ -378,7 +378,7 @@ fn test_get_source_price() {
     register_test_source(&e, &client, "Band");
     let asset1 = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset1, 100i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset1, 100i128, 1234567890);
 
     let entry: PriceEntry = client.get_source_price(&asset1, &source1);
     assert_eq!(entry.price, 100i128);
@@ -410,8 +410,8 @@ fn test_get_all_prices() {
     client.set_min_sources_required(&2u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     let all_prices = client.get_all_prices(&asset);
     assert_eq!(all_prices.len(), 2);
@@ -463,8 +463,8 @@ fn test_historical_prices() {
     client.set_min_sources_required(&2u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 110i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 110i128, 1234567890);
 
     assert!(client.has_historical_price(&asset, &100u32));
 
@@ -491,19 +491,19 @@ fn test_historical_prices_multiple() {
     let asset = register_test_asset(&e, &client);
 
     ledger_default(&e, 100, 1234567890);
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
-    submit_test_price(&client, &source3, &asset, 300i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
+    submit_test_price(&client, &source3, &asset, 300i128, 1234567890);
 
     ledger_default(&e, 101, 1234567891);
-    submit_test_price(&client, &source1, &asset, 110i128, 1234567891, 2);
-    submit_test_price(&client, &source2, &asset, 210i128, 1234567891, 2);
-    submit_test_price(&client, &source3, &asset, 310i128, 1234567891, 2);
+    submit_test_price(&client, &source1, &asset, 110i128, 1234567891);
+    submit_test_price(&client, &source2, &asset, 210i128, 1234567891);
+    submit_test_price(&client, &source3, &asset, 310i128, 1234567891);
 
     ledger_default(&e, 102, 1234567892);
-    submit_test_price(&client, &source1, &asset, 120i128, 1234567892, 3);
-    submit_test_price(&client, &source2, &asset, 220i128, 1234567892, 3);
-    submit_test_price(&client, &source3, &asset, 320i128, 1234567892, 3);
+    submit_test_price(&client, &source1, &asset, 120i128, 1234567892);
+    submit_test_price(&client, &source2, &asset, 220i128, 1234567892);
+    submit_test_price(&client, &source3, &asset, 320i128, 1234567892);
 
     let history_range = client.get_historical_prices(&asset, &100u32, &102u32);
     assert_eq!(history_range.len(), 3);
@@ -706,14 +706,14 @@ fn test_multiple_assets() {
     let eth = register_test_asset(&e, &client);
     let btc = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &xlm, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &xlm, 102i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &xlm, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &xlm, 102i128, 1234567890);
 
-    submit_test_price(&client, &source1, &eth, 180000i128, 1234567890, 2);
-    submit_test_price(&client, &source2, &eth, 181000i128, 1234567890, 2);
+    submit_test_price(&client, &source1, &eth, 180000i128, 1234567890);
+    submit_test_price(&client, &source2, &eth, 181000i128, 1234567890);
 
-    submit_test_price(&client, &source1, &btc, 30000000i128, 1234567890, 3);
-    submit_test_price(&client, &source2, &btc, 31000000i128, 1234567890, 3);
+    submit_test_price(&client, &source1, &btc, 30000000i128, 1234567890);
+    submit_test_price(&client, &source2, &btc, 31000000i128, 1234567890);
 
     let xlm_price = client.get_price(&xlm, &0u64).unwrap();
     assert_eq!(xlm_price.price, 101i128);
@@ -736,13 +736,13 @@ fn test_submit_price_updates_timestamp() {
     client.set_min_sources_required(&2u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1000, 1);
-    submit_test_price(&client, &source2, &asset, 110i128, 2000, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1000);
+    submit_test_price(&client, &source2, &asset, 110i128, 2000);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.timestamp, 2000u64);
 
-    submit_test_price(&client, &source2, &asset, 120i128, 3000, 2);
+    submit_test_price(&client, &source2, &asset, 120i128, 3000);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.timestamp, 3000u64);
@@ -758,7 +758,7 @@ fn test_single_source_no_aggregation() {
     client.set_min_sources_required(&1u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 100i128);
@@ -778,8 +778,8 @@ fn test_price_source_not_affected_by_other_assets() {
     let asset_a = register_test_asset(&e, &client);
     let asset_b = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset_a, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset_a, 110i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset_a, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset_a, 110i128, 1234567890);
 
     let price_a = client.get_price(&asset_a, &0u64).unwrap();
     assert_eq!(price_a.price, 105i128);
@@ -835,8 +835,8 @@ fn test_sep40_lastprice() {
     client.set_min_sources_required(&2u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 110i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 110i128, 1234567890);
 
     let result = client.lastprice(&Asset::Stellar(asset));
     assert!(result.is_some());
@@ -877,7 +877,7 @@ fn test_sep40_lastprice_stale() {
     client.set_resolution(&10u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
 
     // Advance ledger past resolution window
     ledger_default(&e, 200, 1234567910);
@@ -896,8 +896,8 @@ fn test_sep40_price() {
     client.set_min_sources_required(&2u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 110i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 110i128, 1234567890);
 
     let result = client.price(&Asset::Stellar(asset), &1234567890u64);
     assert!(result.is_some());
@@ -916,7 +916,7 @@ fn test_sep40_price_wrong_timestamp() {
     client.set_min_sources_required(&1u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1000, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1000);
 
     // Query with timestamp before data exists → should find no match
     let result = client.price(&Asset::Stellar(asset), &999u64);
@@ -944,9 +944,9 @@ fn test_sep40_prices() {
     client.set_min_sources_required(&3u32);
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
-    submit_test_price(&client, &source3, &asset, 300i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
+    submit_test_price(&client, &source3, &asset, 300i128, 1234567890);
 
     let result = client.prices(&Asset::Stellar(asset), &5u32);
     assert!(result.is_some());
@@ -1006,7 +1006,7 @@ fn test_submit_price_current_timestamp_accepted() {
     let (client, _admin, source, asset) = setup_basic(&e);
 
     // Timestamp equal to ledger time — accepted
-    client.submit_price(&source, &asset, &100i128, &1000u64, &1u64);
+    client.submit_price(&source, &asset, &100i128, &1000u64);
 }
 
 #[test]
@@ -1016,7 +1016,7 @@ fn test_submit_price_past_timestamp_accepted() {
     let (client, _admin, source, asset) = setup_basic(&e);
 
     // Timestamp in the past — accepted
-    client.submit_price(&source, &asset, &100i128, &500u64, &1u64);
+    client.submit_price(&source, &asset, &100i128, &500u64);
 }
 
 #[test]
@@ -1026,7 +1026,7 @@ fn test_submit_price_slightly_future_timestamp_accepted() {
     let (client, _admin, source, asset) = setup_basic(&e);
 
     // Timestamp within threshold (default 300s) — accepted
-    client.submit_price(&source, &asset, &100i128, &1299u64, &1u64);
+    client.submit_price(&source, &asset, &100i128, &1299u64);
 }
 
 #[test]
@@ -1037,7 +1037,7 @@ fn test_submit_price_far_future_timestamp_rejected() {
     let (client, _admin, source, asset) = setup_basic(&e);
 
     // Timestamp more than 5 minutes (300s) in the future — rejected
-    client.submit_price(&source, &asset, &100i128, &1301u64, &1u64);
+    client.submit_price(&source, &asset, &100i128, &1301u64);
 }
 
 #[test]
@@ -1063,7 +1063,7 @@ fn test_timestamp_threshold_configurable() {
     client.set_timestamp_threshold(&600u64);
 
     // Now 1599 should be accepted (within 600s)
-    client.submit_price(&source, &asset, &100i128, &1599u64, &1u64);
+    client.submit_price(&source, &asset, &100i128, &1599u64);
 }
 
 #[test]
@@ -1076,7 +1076,7 @@ fn test_timestamp_threshold_custom_rejects_beyond() {
     client.set_timestamp_threshold(&60u64);
 
     // 1061 is 61s in future — beyond custom threshold of 60s
-    client.submit_price(&source, &asset, &100i128, &1061u64, &1u64);
+    client.submit_price(&source, &asset, &100i128, &1061u64);
 }
 
 // ---- Asset Lifecycle Tests ----
@@ -1092,7 +1092,7 @@ fn test_asset_lifecycle_register_submit_unregister_reregister() {
     let asset = register_test_asset(&e, &client);
 
     // Submit a price
-    submit_test_price(&client, &source, &asset, 500i128, 1000, 1);
+    submit_test_price(&client, &source, &asset, 500i128, 1000);
     let price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(price.price, 500i128);
     assert_eq!(price.price, 500i128);
@@ -1121,7 +1121,7 @@ fn test_asset_lifecycle_register_submit_unregister_reregister() {
     assert!(client.get_price(&asset, &0u64).is_none());
 
     // Submit new price after re-registration
-    submit_test_price(&client, &source, &asset, 600i128, 1000, 2);
+    submit_test_price(&client, &source, &asset, 600i128, 1000);
     let new_price = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(new_price.price, 600i128);
 }
@@ -1148,7 +1148,7 @@ fn test_asset_reregister_after_unregister() {
 
     let asset_addr = Address::generate(&e);
     client.register_asset(&asset_addr);
-    submit_test_price(&client, &source, &asset_addr, 100i128, 1000, 1);
+    submit_test_price(&client, &source, &asset_addr, 100i128, 1000);
 
     client.unregister_asset(&asset_addr);
 
@@ -1157,7 +1157,7 @@ fn test_asset_reregister_after_unregister() {
     assert!(client.is_asset_registered(&asset_addr));
 
     // Submit fresh price
-    submit_test_price(&client, &source, &asset_addr, 200i128, 1000, 2);
+    submit_test_price(&client, &source, &asset_addr, 200i128, 1000);
     let p = client.get_price(&asset_addr, &0u64).unwrap();
     assert_eq!(p.price, 200i128);
 }
@@ -1173,13 +1173,13 @@ fn test_removed_source_cannot_submit_prices() {
     let source = register_test_source(&e, &client, "Oracle");
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source, &asset, 100i128, 1000, 1);
+    submit_test_price(&client, &source, &asset, 100i128, 1000);
 
     client.remove_source(&source);
 
     // Removed source cannot submit
     assert!(client
-        .try_submit_price(&source, &asset, &200i128, &1000u64, &1u64)
+        .try_submit_price(&source, &asset, &200i128, &1000u64)
         .is_err());
 }
 
@@ -1194,8 +1194,8 @@ fn test_removed_source_price_not_in_get_all_prices() {
     let source2 = register_test_source(&e, &client, "Oracle2");
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1000, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1000, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1000);
+    submit_test_price(&client, &source2, &asset, 200i128, 1000);
 
     // Remove source1
     client.remove_source(&source1);
@@ -1218,8 +1218,8 @@ fn test_removed_source_historical_price_still_accessible() {
     let source2 = register_test_source(&e, &client, "Oracle2");
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1000, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1000, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1000);
+    submit_test_price(&client, &source2, &asset, 200i128, 1000);
 
     // Aggregate was recorded at ledger 100
     assert!(client.has_historical_price(&asset, &100u32));
@@ -1861,7 +1861,7 @@ fn test_median_duplicate_source_no_inflation() {
     submit_test_price(&client, &source1, &asset, 500i128, 2000);
     let second_agg = client.get_price(&asset, &0u64).unwrap();
     assert_eq!(second_agg.price, 325i128); // median(500, 150) = 325
-    // Still only 2 contributors — the overwrite did not inflate the count
+                                           // Still only 2 contributors — the overwrite did not inflate the count
     assert_eq!(second_agg.num_sources, 2u32);
 }
 
@@ -1886,12 +1886,15 @@ fn test_subscription_bypasses_rate_limit() {
     // Subscribed consumer can make many queries without hitting rate limit
     for _ in 0..10 {
         let _ = client.get_price(&asset, &0u64);
+    }
+}
+
 // ===== Issue #85: Strict Input Validation Tests =====
 
 // --- add_source name validation ---
 
 #[test]
-#[should_panic(expected = "Error(Contract, #16)")]
+#[should_panic(expected = "Error(Contract, #21)")]
 fn test_add_source_empty_name_rejected() {
     let e = Env::default();
     let (client, _) = setup_contract(&e);
@@ -1900,13 +1903,16 @@ fn test_add_source_empty_name_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #17)")]
+#[should_panic(expected = "Error(Contract, #22)")]
 fn test_add_source_name_too_long_rejected() {
     let e = Env::default();
     let (client, _) = setup_contract(&e);
     let source = soroban_sdk::Address::generate(&e);
     // 65-character name (max is 64)
-    let long_name = String::from_str(&e, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let long_name = String::from_str(
+        &e,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
     client.add_source(&source, &long_name);
 }
 
@@ -1916,7 +1922,10 @@ fn test_add_source_name_exactly_64_chars_accepted() {
     let (client, _) = setup_contract(&e);
     let source = soroban_sdk::Address::generate(&e);
     // exactly 64 characters
-    let name = String::from_str(&e, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let name = String::from_str(
+        &e,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
     client.add_source(&source, &name);
     assert!(client.is_source(&source));
 }
@@ -1971,7 +1980,7 @@ fn test_initialize_decimals_above_18_rejected() {
 // --- override_price reason length validation ---
 
 #[test]
-#[should_panic(expected = "Error(Contract, #20)")]
+#[should_panic(expected = "Error(Contract, #29)")]
 fn test_override_price_reason_too_long_rejected() {
     let e = Env::default();
     ledger_default(&e, 100, 1234567890);
@@ -2003,7 +2012,7 @@ fn test_override_price_reason_exactly_256_chars_accepted() {
 // --- prices SEP-40 records cap validation ---
 
 #[test]
-#[should_panic(expected = "Error(Contract, #19)")]
+#[should_panic(expected = "Error(Contract, #30)")]
 fn test_prices_records_exceeds_max_history_rejected() {
     let e = Env::default();
     ledger_default(&e, 100, 1234567890);
@@ -2028,7 +2037,7 @@ fn test_prices_records_at_max_history_accepted() {
 // --- propose_operation invalid op_type validation ---
 
 #[test]
-#[should_panic(expected = "Error(Contract, #18)")]
+#[should_panic(expected = "Error(Contract, #24)")]
 fn test_propose_operation_invalid_type_rejected() {
     let e = Env::default();
     let (client, _) = setup_contract(&e);
@@ -2114,7 +2123,9 @@ fn test_migrate_pause_and_resume() {
     // First call: processes asset[0], pauses (cursor=1).
     client.migrate_storage(&1u32);
     assert_eq!(client.get_storage_version(), 1u32); // not done yet
-    let state = client.get_migration_state().expect("state should exist after pause");
+    let state = client
+        .get_migration_state()
+        .expect("state should exist after pause");
     assert_eq!(state.cursor, 1u32);
     assert_eq!(state.from_version, 1u32);
     assert_eq!(state.to_version, 2u32);
@@ -2122,7 +2133,9 @@ fn test_migrate_pause_and_resume() {
     // Second call: processes asset[1], pauses (cursor=2).
     client.migrate_storage(&1u32);
     assert_eq!(client.get_storage_version(), 1u32);
-    let state2 = client.get_migration_state().expect("state should still exist");
+    let state2 = client
+        .get_migration_state()
+        .expect("state should still exist");
     assert_eq!(state2.cursor, 2u32);
 
     // Third call: processes asset[2], completes.

--- a/contracts/price-oracle/src/test_helpers.rs
+++ b/contracts/price-oracle/src/test_helpers.rs
@@ -53,9 +53,8 @@ pub fn submit_test_price(
     asset: &Address,
     price: i128,
     timestamp: u64,
-    nonce: u64,
 ) {
-    client.submit_price(source, asset, &price, &timestamp, &nonce);
+    client.submit_price(source, asset, &price, &timestamp);
 }
 
 /// Creates an initialized contract with N sources and M assets; sets min_sources to N.

--- a/contracts/price-oracle/src/timelock.rs
+++ b/contracts/price-oracle/src/timelock.rs
@@ -307,9 +307,7 @@ fn execute_single_op(env: &Env, op_type: u32, data: &Bytes) {
                     arr[j as usize] = data.get_unchecked(j);
                 }
                 let val = u32::from_be_bytes(arr);
-                env.storage()
-                    .persistent()
-                    .set(&DataKey::Resolution, &val);
+                env.storage().persistent().set(&DataKey::Resolution, &val);
             }
         }
         5 => {
@@ -320,9 +318,7 @@ fn execute_single_op(env: &Env, op_type: u32, data: &Bytes) {
                     arr[j as usize] = data.get_unchecked(j);
                 }
                 let val = u32::from_be_bytes(arr);
-                env.storage()
-                    .persistent()
-                    .set(&DataKey::Decimals, &val);
+                env.storage().persistent().set(&DataKey::Decimals, &val);
             }
         }
         6 => {

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -30,8 +30,6 @@ pub enum DataKey {
     ReentrancyGuard,
     /// Existence flag for a registered oracle source (`true` when present).
     Source(Address),
-    /// Existence flag for a registered asset (`true` when present).
-    AssetRegistered(Address),
     /// Latest [`PriceEntry`] submitted by a specific source for a specific asset.
     Submission(Address, Address),
     /// Ledger sequence number of the last submission by a source for an asset.
@@ -106,7 +104,7 @@ pub enum DataKey {
     /// Monotonically incrementing counter used to assign IDs to pending operations.
     TlPendingOpCount,
     /// A [`PendingOperation`] awaiting timelock expiry before execution.
-    PendingOp(u32),
+    TlPendingOp(u32),
     /// Number of ledgers that must pass between proposing and executing a timelock operation.
     TimelockDuration,
     /// Tracks the number of queries made by a consumer for a specific ledger.
@@ -140,8 +138,6 @@ pub enum DataKey {
     MigrationState,
 
     // --- #66: Phased removal (used in sources.rs but missing from original enum) ---
-    /// Alias key used by phased-removal logic in sources.rs (mirrors SrcActive).
-    Source(Address),
     /// Ledger at which a source becomes eligible for finalization after mark_source_for_removal.
     SourcePendingRemoval(Address),
     /// Decay factor for source reputation scores (u32, out of 100).
@@ -154,17 +150,40 @@ pub enum DataKey {
     MaxPriceDeviation,
     /// Timestamp threshold key used in admin.rs set path (mirrors CfgTimestampThreshold).
     TimestampThreshold,
+    /// Minimum sources key used in timelock.rs batch execution (mirrors CfgMinSources).
+    MinSourcesRequired,
+    /// Max history length key used in timelock.rs batch execution (mirrors CfgMaxHistory).
+    MaxHistoryLength,
+    /// Resolution key used in timelock.rs batch execution (mirrors CfgResolution).
+    Resolution,
+    /// Decimals key used in timelock.rs batch execution (mirrors CfgDecimals).
+    Decimals,
+
+    // -------------------------------------------------------------------------
+    // #92/#93/#94: event spam protection, max aggregation sources, per-asset history cap
+    // -------------------------------------------------------------------------
+    /// Per-asset maximum number of price entries before the oldest is pruned (issue #94).
+    MaxHistoryPerAsset,
+    /// Maximum number of events that may be emitted in a single call (issue #92).
+    MaxEventsPerCall,
+    /// Maximum number of sources used for aggregation; excess sources are randomly
+    /// sub-sampled using the ledger hash (issue #93).
+    MaxAggregationSources,
+    /// Maximum number of oracle sources that may be registered. `0` = unlimited.
+    MaxSources,
+    /// Whether linear interpolation is used for historical price lookups that miss
+    /// an exact ledger match.
+    InterpolationEnabled,
 
     // -------------------------------------------------------------------------
     // #186: Adaptive heartbeat / liveness detection
     // -------------------------------------------------------------------------
-
     /// Number of consecutive missed heartbeats for a source (u32).
     SrcMissedHeartbeats(Address),
     /// Ledger sequence of the last price submission from a source (u32).
     SrcLastPriceLedger(Address),
     /// Flag: source has submitted a price since its last heartbeat reactivation (bool).
-    SrcPriceSubmittedAfterReactivation(Address),
+    SrcPriceSubmitAfterReactivation(Address),
     /// Ledger sequence at which a source first became inactive — for auto-removal timer (u32).
     SrcInactiveSinceLedger(Address),
     /// Maximum ledgers a source may remain inactive before automatic removal (u32).
@@ -175,7 +194,6 @@ pub enum DataKey {
     // -------------------------------------------------------------------------
     // #187: Commit-reveal MEV resistance
     // -------------------------------------------------------------------------
-
     /// A pending price commit: stores PriceCommit under (asset, source, round_ledger).
     PriceCommit(Address, Address, u32),
     /// Number of ledgers that the commit phase lasts (sources must commit within this window).
@@ -186,7 +204,6 @@ pub enum DataKey {
     // -------------------------------------------------------------------------
     // #188: Economic finality gadget
     // -------------------------------------------------------------------------
-
     /// A pending finality entry for an asset at a given ledger (PendingFinalityEntry).
     PendingFinality(Address, u32),
     /// Number of ledgers to wait before an aggregated price is considered finalized (u32).
@@ -195,6 +212,78 @@ pub enum DataKey {
     LedgerHashChain(u32),
     /// The finalized aggregate price for an asset (FinalizedPrice).
     FinalizedPrice(Address),
+
+    // -------------------------------------------------------------------------
+    // #171: Source Reputation & Slashing
+    // -------------------------------------------------------------------------
+    /// Staking record for an oracle source (SourceStakeRecord).
+    SourceStake(Address),
+    /// Address of the XLM/oracle token contract used for staking and fees.
+    StakeTokenContract,
+    /// Percentage of stake to slash (u32, 0–100) per slash event.
+    SlashPercent,
+    /// Threshold below which a source's reputation triggers slash eligibility (u32, 0–100).
+    SlashReputationThreshold,
+    /// Total slashed funds held in contract treasury (i128 stroops).
+    TreasuryBalance,
+
+    // -------------------------------------------------------------------------
+    // #172: Cross-Asset Correlation
+    // -------------------------------------------------------------------------
+    /// Min/max ratio band for a (base_asset, quote_asset) pair.
+    CorrelationBand(Address, Address),
+    /// Ordered list of (base, quote) correlation pairs registered.
+    CorrelationPairList,
+
+    // -------------------------------------------------------------------------
+    // #173: Tiered Consumer Whitelisting
+    // -------------------------------------------------------------------------
+    /// Consumer tier and quota info for an address.
+    ConsumerInfo(Address),
+    /// Pricing for each tier (ConsumerTier discriminant → price in stroops per ledger cycle).
+    TierPricing(u32),
+    /// Per-ledger query counter for a tiered consumer.
+    TierQueryCount(Address, u32),
+    /// Treasury address for XLM fee sweeps.
+    WhitelistTreasury,
+    /// Address of the XLM token contract used for subscription fee collection.
+    XlmTokenContract,
+
+    // -------------------------------------------------------------------------
+    // #174: Price Deviation Alerts
+    // -------------------------------------------------------------------------
+    /// Alert subscription record for a (consumer, asset) pair.
+    AlertSubscription(Address, Address),
+    /// Ordered list of (consumer, asset) pairs that have active alert subscriptions.
+    AlertSubscriptionList,
+    /// Maximum number of alert subscriptions allowed globally.
+    MaxAlertSubscriptions,
+    /// TTL in ledgers for alert subscriptions before auto-expiry.
+    AlertSubscriptionTtl,
+    /// Last aggregate price recorded per asset for deviation comparison.
+    AlertLastPrice(Address),
+
+    // -------------------------------------------------------------------------
+    // Off-chain relayer network integration
+    // -------------------------------------------------------------------------
+    /// Metadata for an approved relayer address.
+    ApprovedRelayer(Address),
+    /// Fee (in stroops) credited to a relayer per successful relayed price submission.
+    RelayerFeePerSubmission,
+    /// Accumulated fee balance (in stroops) owed to a relayer.
+    RelayerFeeBalance(Address),
+    /// Running count of successful price submissions made by a relayer.
+    RelayerSubmissionCount(Address),
+
+    // -------------------------------------------------------------------------
+    // Cross-reference oracle checks
+    // -------------------------------------------------------------------------
+    /// Stored [`ReferenceOracleEntry`] for a registered external reference oracle.
+    ReferenceOracle(Address),
+    /// Ordered list of registered reference oracle contract addresses.
+    ReferenceOracleList,
+    /// Allowed deviation in basis points before a cross-reference alert is emitted.
+    CrossRefDeviationThreshold,
 }
 
 /// A price submission from a single oracle source for a specific asset.
@@ -575,4 +664,158 @@ pub struct FinalizedPrice {
     pub committed_ledger: u32,
     /// Ledger at which finality was confirmed.
     pub finalized_ledger: u32,
+}
+
+// =============================================================================
+// #171 — Source Reputation & Slashing
+// =============================================================================
+
+/// Staking record for an oracle source.
+///
+/// Stored under [`DataKey::SourceStake`] keyed by source address.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct SourceStakeRecord {
+    /// Locked stake amount in stroops.
+    pub amount: i128,
+    /// Ledger at which the stake was last updated.
+    pub last_updated_ledger: u32,
+}
+
+// =============================================================================
+// #172 — Cross-Asset Correlation
+// =============================================================================
+
+/// Acceptable ratio band between two correlated assets.
+///
+/// The ratio is computed as `price_base * RATIO_PRECISION / price_quote` and must
+/// fall within `[min_ratio, max_ratio]`. All values are scaled by `RATIO_PRECISION`
+/// (10^7) to avoid floating-point arithmetic.
+///
+/// Stored under [`DataKey::CorrelationBand`] keyed by `(base_asset, quote_asset)`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CorrelationBand {
+    /// Minimum acceptable ratio (scaled by 10^7).
+    pub min_ratio: u128,
+    /// Maximum acceptable ratio (scaled by 10^7).
+    pub max_ratio: u128,
+    /// Whether this correlation check is currently active.
+    pub enabled: bool,
+}
+
+/// A registered correlation pair for enumeration purposes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CorrelationPair {
+    pub base_asset: Address,
+    pub quote_asset: Address,
+}
+
+// =============================================================================
+// #173 — Tiered Consumer Access
+// =============================================================================
+
+/// Consumer access tier.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum ConsumerTier {
+    /// Free tier: 10 queries/ledger, data up to 1-hour stale.
+    Free = 0,
+    /// Basic tier: 100 queries/ledger, max 30-second fresh data.
+    Basic = 1,
+    /// Premium tier: unlimited queries/ledger, real-time data.
+    Premium = 2,
+}
+
+/// Per-consumer tier, quota, and subscription state.
+///
+/// Stored under [`DataKey::ConsumerInfo`] keyed by consumer address.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ConsumerInfo {
+    /// Current access tier.
+    pub tier: ConsumerTier,
+    /// Ledger-based subscription expiration. 0 = no active subscription.
+    pub subscription_expiry_ledger: u32,
+    /// Unix timestamp-based subscription expiration. 0 = no active subscription.
+    pub subscription_expiry_ts: u64,
+    /// Number of queries consumed in the current ledger.
+    pub queries_this_ledger: u32,
+    /// Ledger sequence for which `queries_this_ledger` was last reset.
+    pub quota_reset_ledger: u32,
+}
+
+// =============================================================================
+// #174 — On-Chain Alert Subscriptions
+// =============================================================================
+
+/// An alert subscription record.
+///
+/// Stored under [`DataKey::AlertSubscription`] keyed by `(consumer, asset)`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct AlertSubscription {
+    /// Address of the subscriber (consumer contract or account).
+    pub consumer: Address,
+    /// Asset being monitored.
+    pub asset: Address,
+    /// Price movement threshold in basis points (100 bps = 1%) that triggers an alert.
+    pub threshold_bps: u32,
+    /// Contract address to invoke when the threshold is breached.
+    pub callback_contract: Address,
+    /// Function selector (Symbol) on the callback contract to call.
+    pub callback_fn: Symbol,
+    /// Ledger at which this subscription was created or last renewed.
+    pub created_ledger: u32,
+    /// TTL in ledgers; subscription expires at `created_ledger + ttl`.
+    pub ttl_ledgers: u32,
+}
+
+// =============================================================================
+// Off-chain relayer network integration
+// =============================================================================
+
+/// Metadata stored for each admin-approved relayer.
+///
+/// Stored under [`DataKey::ApprovedRelayer`] keyed by relayer address.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RelayerInfo {
+    /// Human-readable display name for this relayer.
+    pub name: String,
+    /// Ledger sequence number when the relayer was approved by the admin.
+    pub approved_at_ledger: u32,
+}
+
+// =============================================================================
+// Cross-reference oracle checks
+// =============================================================================
+
+/// A registered external oracle contract used for cross-reference price checks.
+///
+/// Stored under [`DataKey::ReferenceOracle`] keyed by the oracle's contract address.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ReferenceOracleEntry {
+    /// Contract address of the external oracle.
+    pub contract_id: Address,
+    /// Maps our asset addresses to the corresponding asset addresses used by the reference oracle.
+    pub asset_mapping: Map<Address, Address>,
+}
+
+/// The result of a cross-reference price comparison for a single asset.
+///
+/// Returned by `get_cross_reference`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CrossReferenceResult {
+    /// Our current aggregated price for the asset.
+    pub our_price: i128,
+    /// Price reported by the reference oracle for the same asset.
+    pub ref_price: i128,
+    /// Absolute deviation between the two prices expressed in basis points (1 % = 100 bps).
+    pub deviation_bps: u32,
+    /// Contract address of the reference oracle that provided `ref_price`.
+    pub ref_contract: Address,
 }

--- a/contracts/price-oracle/src/whitelist_tests.rs
+++ b/contracts/price-oracle/src/whitelist_tests.rs
@@ -126,8 +126,8 @@ fn test_whitelist_disabled_by_default() {
 
     let asset = register_test_asset(&e, &client);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     // Without whitelist enabled, any caller should be able to query
     let price = client.get_price(&asset, &0u64);
@@ -150,8 +150,8 @@ fn test_whitelisted_consumer_can_query() {
     client.add_consumer(&consumer);
     client.set_whitelist_enabled(&true);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     // Whitelisted consumer should be able to query
     let price = client.get_price(&asset, &0u64);
@@ -177,8 +177,8 @@ fn test_non_whitelisted_consumer_cannot_query() {
     client.add_consumer(&whitelisted);
     client.set_whitelist_enabled(&true);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     // Try to query as unauthorized consumer (should fail)
     clear_auth(&e);
@@ -201,8 +201,8 @@ fn test_admin_can_always_query() {
     client.set_whitelist_enabled(&true);
     // Admin not in whitelist but should still be able to query
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     let price = client.get_price(&asset, &0u64);
     assert!(price.is_some());
@@ -251,8 +251,8 @@ fn test_toggle_whitelist_enables_restrictions() {
     let asset = register_test_asset(&e, &client);
     let consumer = Address::generate(&e);
 
-    submit_test_price(&client, &source1, &asset, 100i128, 1234567890, 1);
-    submit_test_price(&client, &source2, &asset, 200i128, 1234567890, 1);
+    submit_test_price(&client, &source1, &asset, 100i128, 1234567890);
+    submit_test_price(&client, &source2, &asset, 200i128, 1234567890);
 
     // Initially whitelist is disabled, query works
     assert!(client.get_price(&asset, &0u64).is_some());

--- a/contracts/price-oracle/src/whitelisting.rs
+++ b/contracts/price-oracle/src/whitelisting.rs
@@ -73,12 +73,10 @@ pub fn register_consumer(env: &Env, consumer: Address, tier: ConsumerTier) {
 
     let (expiry_ts, expiry_ledger) = match tier {
         ConsumerTier::Free => (0u64, 0u32), // Free = permanent, no expiry tracking
-        ConsumerTier::Basic | ConsumerTier::Premium => {
-            (
-                current_ts.saturating_add(THIRTY_DAYS_SECS),
-                current_ledger.saturating_add(THIRTY_DAYS_LEDGERS),
-            )
-        }
+        ConsumerTier::Basic | ConsumerTier::Premium => (
+            current_ts.saturating_add(THIRTY_DAYS_SECS),
+            current_ledger.saturating_add(THIRTY_DAYS_LEDGERS),
+        ),
     };
 
     // Collect fee for paid tiers.
@@ -168,17 +166,16 @@ pub fn check_and_record_query(env: &Env, consumer: &Address) -> u64 {
     let info_key = DataKey::ConsumerInfo(consumer.clone());
     let info_opt: Option<ConsumerInfo> = env.storage().persistent().get(&info_key);
 
-    let (tier, sub_expiry_ledger, sub_expiry_ts, mut queries, quota_reset_ledger) =
-        match info_opt {
-            Some(ref i) => (
-                i.tier.clone(),
-                i.subscription_expiry_ledger,
-                i.subscription_expiry_ts,
-                i.queries_this_ledger,
-                i.quota_reset_ledger,
-            ),
-            None => (ConsumerTier::Free, 0u32, 0u64, 0u32, current_ledger),
-        };
+    let (tier, sub_expiry_ledger, sub_expiry_ts, mut queries, quota_reset_ledger) = match info_opt {
+        Some(ref i) => (
+            i.tier.clone(),
+            i.subscription_expiry_ledger,
+            i.subscription_expiry_ts,
+            i.queries_this_ledger,
+            i.quota_reset_ledger,
+        ),
+        None => (ConsumerTier::Free, 0u32, 0u64, 0u32, current_ledger),
+    };
 
     // Validate subscription expiry for paid tiers.
     match tier {
@@ -240,9 +237,11 @@ pub fn set_tier_pricing(env: &Env, tier: ConsumerTier, price: i128) {
     env.storage()
         .persistent()
         .set(&DataKey::TierPricing(disc), &price);
-    env.storage()
-        .persistent()
-        .extend_ttl(&DataKey::TierPricing(disc), LEDGER_THRESHOLD, LEDGER_BUMP);
+    env.storage().persistent().extend_ttl(
+        &DataKey::TierPricing(disc),
+        LEDGER_THRESHOLD,
+        LEDGER_BUMP,
+    );
 }
 
 /// Returns the subscription fee in stroops for a given tier.
@@ -251,10 +250,7 @@ pub fn get_tier_price(env: &Env, tier: ConsumerTier) -> i128 {
 }
 
 fn get_tier_price_internal(env: &Env, disc: u32) -> i128 {
-    let stored: Option<i128> = env
-        .storage()
-        .persistent()
-        .get(&DataKey::TierPricing(disc));
+    let stored: Option<i128> = env.storage().persistent().get(&DataKey::TierPricing(disc));
 
     stored.unwrap_or(match disc {
         0 => 0,
@@ -273,9 +269,11 @@ pub fn set_xlm_token_contract(env: &Env, token: Address) {
     env.storage()
         .persistent()
         .set(&DataKey::XlmTokenContract, &token);
-    env.storage()
-        .persistent()
-        .extend_ttl(&DataKey::XlmTokenContract, LEDGER_THRESHOLD, LEDGER_BUMP);
+    env.storage().persistent().extend_ttl(
+        &DataKey::XlmTokenContract,
+        LEDGER_THRESHOLD,
+        LEDGER_BUMP,
+    );
 }
 
 /// Returns the configured XLM token contract address.
@@ -292,16 +290,16 @@ pub fn set_whitelist_treasury(env: &Env, treasury: Address) {
     env.storage()
         .persistent()
         .set(&DataKey::WhitelistTreasury, &treasury);
-    env.storage()
-        .persistent()
-        .extend_ttl(&DataKey::WhitelistTreasury, LEDGER_THRESHOLD, LEDGER_BUMP);
+    env.storage().persistent().extend_ttl(
+        &DataKey::WhitelistTreasury,
+        LEDGER_THRESHOLD,
+        LEDGER_BUMP,
+    );
 }
 
 /// Returns the configured treasury address, or `None` if not set.
 pub fn get_whitelist_treasury(env: &Env) -> Option<Address> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::WhitelistTreasury)
+    env.storage().persistent().get(&DataKey::WhitelistTreasury)
 }
 
 /// Sweeps all collected subscription fees held by the contract to the treasury address.


### PR DESCRIPTION
this pr closes #230 
this pr closes #231 
this pr closes #232 
this pr closes #233 

main was broken: three separate merges (PR #315/#316, the relayer/cross- reference commit, and the #92/#93/#94 event-budget commit) each dropped one side's changes to the shared types.rs/errors.rs/events.rs/admin.rs/lib.rs files while keeping the feature modules that depended on them.

- types.rs: dedupe DataKey::AssetRegistered/Source (declared twice), restore missing variants/structs for reputation, correlation, whitelisting, alerts, relayer, and cross-reference; add Cfg-alias keys timelock.rs expected
- errors.rs / events.rs: restore missing error codes and event structs; rename 7 events whose auto-derived topic (snake_case of the full struct name) silently exceeded Soroban's 32-char Symbol limit, causing proc-macro panics with no useful diagnostic
- admin.rs: restore missing accessors (asset resolution, aggregation cooldown, min submission interval, interpolation toggle, max sources) and fix a use-block that had event imports spliced into a storage import
- lib.rs: dedupe six #[contractimpl] methods that existed twice; wire up the #92/#93/#94 admin endpoints (max history/events/aggregation-sources) that were implemented but never exposed; fix a couple of borrow/type mismatches
- prices.rs: fix the #93 max-aggregation-sources subsampling, which computed a `selected_sources` subset but then aggregated over all sources anyway
- prices.rs / finality.rs / commit_reveal_tests.rs: env.crypto().sha256() returns Hash<32>, not BytesN<32>, in this soroban-sdk version
- sources.rs: max-sources cap treated 0 (=unlimited) as a real limit of zero, rejecting the very first registered source
- test.rs and friends: submit_test_price's never-wired nonce parameter (leftover from an abandoned companion branch) removed; stale should_panic error-code expectations updated to match current numbering; an unclosed brace that had swallowed a later test's doc-comment restored
- cargo fmt + clippy -D warnings now pass; the four still-unwired feature modules (reputation/staking #171, correlation #172, whitelisting #173, alerts #174) are marked with a crate-level dead_code allow and a comment explaining they're implemented but not yet exposed as contract endpoints

Result: cargo build and clippy are clean; cargo test went from not compiling at all to 221 passing / 20 failing. Remaining failures are mostly further stale should_panic expectations and a WASM-upload budget issue in the upgrade tests — left for follow-up per request.

## Description

<!-- What does this PR do? Why is it needed? -->

## Related issue

<!-- Link to the GitHub issue this resolves, e.g., Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / performance
- [ ] Documentation
- [ ] CI / tooling

## Testing

- [ ] All existing tests pass (`cargo test -p price-oracle --lib`)
- [ ] New tests added for the change
- [ ] Clippy is clean (`cargo clippy -- -D warnings`)
- [ ] Formatting is clean (`cargo fmt -- --check`)

## Checklist

- [ ] My code follows the existing code style and patterns
- [ ] I have updated the README if needed
- [ ] Events are emitted for state-changing operations
- [ ] Authorization checks are in place for admin-only functions
