### PR TITLE
feat: add programmatic price bounds and circuit breaker

### DIFF
--- a/contracts/price-oracle/src/assets.rs
+++ b/contracts/price-oracle/src/assets.rs
@@ -1,10 +1,13 @@
 use soroban_sdk::{panic_with_error, symbol_short, Address, Bytes, Env, Vec};
 
-use crate::events::{emit_admin_action, AssetRegisteredEvent, AssetUnregisteredEvent};
+use crate::events::{
+    emit_admin_action, AssetRegisteredEvent, AssetUnregisteredEvent, CircuitBreakerResetEvent,
+    CircuitBreakerTrippedEvent,
+};
 use crate::storage::{
     get_admin, read_registered_assets, write_registered_assets, LEDGER_BUMP, LEDGER_THRESHOLD,
 };
-use crate::types::{AssetMetadata, DataKey, ErrorCode};
+use crate::types::{AssetMetadata, CircuitBreakerEventEntry, DataKey, ErrorCode, PriceBounds};
 
 pub fn register_asset(env: &Env, asset: Address) {
     let admin = get_admin(env);
@@ -34,6 +37,7 @@ pub fn register_asset(env: &Env, asset: Address) {
 
     assets.push_back(asset.clone());
     write_registered_assets(env, &assets);
+    initialize_asset_price_bounds(env, asset.clone());
 
     AssetRegisteredEvent {
         asset: asset.clone(),
@@ -140,6 +144,10 @@ pub fn set_min_price(env: &Env, asset: Address, min_price: i128) {
 
 pub fn get_min_price(env: &Env, asset: Address) -> i128 {
     crate::storage::check_registered_asset(env, &asset);
+    let bounds = get_price_bounds(env, asset.clone());
+    if bounds.min_price > 0 {
+        return bounds.min_price;
+    }
     let key = DataKey::AssetMinPrice(asset.clone());
     if env.storage().persistent().has(&key) {
         env.storage()
@@ -147,4 +155,159 @@ pub fn get_min_price(env: &Env, asset: Address) -> i128 {
             .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
     }
     env.storage().persistent().get(&key).unwrap_or(0)
+}
+
+pub fn initialize_asset_price_bounds(env: &Env, asset: Address) {
+    let bounds = PriceBounds {
+        min_price: 0,
+        max_price: i128::MAX,
+        max_change_bps_per_ledger: 0,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::AssetPriceBounds(asset.clone()), &bounds);
+    env.storage()
+        .persistent()
+        .set(&DataKey::AssetPauseFlag(asset.clone()), &false);
+    env.storage()
+        .persistent()
+        .set(&DataKey::AssetCircuitBreakerTripped(asset.clone()), &false);
+    env.storage()
+        .persistent()
+        .set(&DataKey::AssetCircuitBreakerLogCount(asset.clone()), &0u32);
+}
+
+pub fn set_price_bounds(
+    env: &Env,
+    asset: Address,
+    min_price: i128,
+    max_price: i128,
+    max_change_bps_per_ledger: u32,
+) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    crate::storage::check_registered_asset(env, &asset);
+    if min_price > max_price {
+        panic_with_error!(env, ErrorCode::InvalidConfiguration);
+    }
+    if max_change_bps_per_ledger > 100_000 {
+        panic_with_error!(env, ErrorCode::InvalidConfiguration);
+    }
+
+    let bounds = PriceBounds {
+        min_price,
+        max_price,
+        max_change_bps_per_ledger,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::AssetPriceBounds(asset.clone()), &bounds);
+    emit_admin_action(env, symbol_short!("set_bounds"), admin, Bytes::new(env));
+}
+
+pub fn get_price_bounds(env: &Env, asset: Address) -> PriceBounds {
+    crate::storage::check_registered_asset(env, &asset);
+    let key = DataKey::AssetPriceBounds(asset.clone());
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage().persistent().get(&key).unwrap_or(PriceBounds {
+        min_price: 0,
+        max_price: i128::MAX,
+        max_change_bps_per_ledger: 0,
+    })
+}
+
+pub fn is_asset_paused(env: &Env, asset: &Address) -> bool {
+    let key = DataKey::AssetPauseFlag(asset.clone());
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage().persistent().get(&key).unwrap_or(false)
+}
+
+pub fn set_asset_paused(env: &Env, asset: &Address, paused: bool) {
+    let key = DataKey::AssetPauseFlag(asset.clone());
+    env.storage().persistent().set(&key, &paused);
+}
+
+pub fn is_circuit_breaker_tripped(env: &Env, asset: &Address) -> bool {
+    let key = DataKey::AssetCircuitBreakerTripped(asset.clone());
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+    env.storage().persistent().get(&key).unwrap_or(false)
+}
+
+pub fn pause_asset(env: &Env, asset: Address) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    crate::storage::check_registered_asset(env, &asset);
+    set_asset_paused(env, &asset, true);
+    emit_admin_action(env, symbol_short!("pause_ast"), admin, Bytes::new(env));
+}
+
+pub fn unpause_asset(env: &Env, asset: Address) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    crate::storage::check_registered_asset(env, &asset);
+    set_asset_paused(env, &asset, false);
+    env.storage()
+        .persistent()
+        .set(&DataKey::AssetCircuitBreakerTripped(asset.clone()), &false);
+    CircuitBreakerResetEvent {
+        asset: asset.clone(),
+        admin: admin.clone(),
+    }
+    .publish(env);
+    emit_admin_action(env, symbol_short!("unp_asts"), admin, Bytes::new(env));
+}
+
+pub fn trip_circuit_breaker(
+    env: &Env,
+    asset: Address,
+    previous_price: i128,
+    candidate_price: i128,
+    change_bps: i128,
+    max_change_bps: u32,
+) {
+    set_asset_paused(env, &asset, true);
+    env.storage()
+        .persistent()
+        .set(&DataKey::AssetCircuitBreakerTripped(asset.clone()), &true);
+
+    let count_key = DataKey::AssetCircuitBreakerLogCount(asset.clone());
+    let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+    let next_count = count + 1;
+    let entry = CircuitBreakerEventEntry {
+        asset: asset.clone(),
+        previous_price,
+        candidate_price,
+        change_bps: change_bps.min(i128::from(u32::MAX)) as u32,
+        max_change_bps,
+        ledger: env.ledger().sequence(),
+        timestamp: env.ledger().timestamp(),
+    };
+    env.storage().persistent().set(
+        &DataKey::AssetCircuitBreakerLog(asset.clone(), next_count),
+        &entry,
+    );
+    env.storage().persistent().set(&count_key, &next_count);
+
+    CircuitBreakerTrippedEvent {
+        asset: asset.clone(),
+        previous_price,
+        candidate_price,
+        change_bps: entry.change_bps,
+        max_change_bps,
+        ledger: env.ledger().sequence(),
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
 }

--- a/contracts/price-oracle/src/circuit_breaker_tests.rs
+++ b/contracts/price-oracle/src/circuit_breaker_tests.rs
@@ -1,0 +1,40 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::{test_helpers::setup_contract, PriceOracleContractClient};
+
+fn setup_price_bounds_case<'a>(e: &'a Env) -> (PriceOracleContractClient<'a>, Address, Address) {
+    let (client, _admin) = setup_contract(e);
+    let source = Address::generate(e);
+    let asset = Address::generate(e);
+    client.add_source(&source, &String::from_str(e, "Source"));
+    client.register_asset(&asset);
+    client.set_min_sources_required(&1u32);
+    client.set_price_bounds(&asset, &100i128, &1000i128, &100u32);
+    (client, source, asset)
+}
+
+#[test]
+fn rejects_out_of_bounds_submissions() {
+    let e = Env::default();
+    let (client, source, asset) = setup_price_bounds_case(&e);
+    let result = std::panic::catch_unwind(|| {
+        client.submit_price(&source, &asset, &1500i128, &1000u64);
+    });
+    assert!(result.is_err());
+}
+
+#[test]
+fn trips_circuit_breaker_for_large_price_move() {
+    let e = Env::default();
+    let (client, source, asset) = setup_price_bounds_case(&e);
+    client.submit_price(&source, &asset, &100i128, &1000u64);
+
+    let result = std::panic::catch_unwind(|| {
+        client.submit_price(&source, &asset, &1000i128, &1001u64);
+    });
+    assert!(result.is_err());
+    assert!(client.is_asset_paused(&asset));
+    assert!(client.is_circuit_breaker_tripped(&asset));
+}

--- a/contracts/price-oracle/src/errors.rs
+++ b/contracts/price-oracle/src/errors.rs
@@ -52,6 +52,12 @@ pub enum ErrorCode {
     OperationNotFound = 14,
     /// The submitted price is below the asset's configured minimum price floor.
     PriceBelowMinimum = 15,
+    /// The submitted price falls outside the asset's configured price bounds.
+    PriceOutOfBounds = 54,
+    /// The asset is currently paused and cannot accept new submissions.
+    AssetPaused = 55,
+    /// The circuit breaker tripped for the asset and rejected the update.
+    CircuitBreakerTripped = 56,
 
     // ── 16–19: Rate-limit, subscription & migration ──────────────────────────
     /// Rate limit exceeded for an operation.

--- a/contracts/price-oracle/src/events.rs
+++ b/contracts/price-oracle/src/events.rs
@@ -237,6 +237,43 @@ pub struct PriceAggregatedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when an asset's circuit breaker trips and the update is rejected.
+///
+/// Topics: `asset`
+#[contractevent]
+#[derive(Clone)]
+pub struct CircuitBreakerTrippedEvent {
+    /// Address of the asset that triggered the breaker.
+    #[topic]
+    pub asset: Address,
+    /// Previous aggregate price before the rejected update.
+    pub previous_price: i128,
+    /// Candidate aggregate price that would have been published.
+    pub candidate_price: i128,
+    /// Change amount in basis points that exceeded the configured limit.
+    pub change_bps: u32,
+    /// Maximum allowed change in basis points for a single ledger.
+    pub max_change_bps: u32,
+    /// Ledger at which the breaker tripped.
+    pub ledger: u32,
+    /// Unix timestamp of the breaker trip.
+    pub timestamp: u64,
+}
+
+/// Emitted when the circuit breaker is manually reset by the admin.
+///
+/// Topics: `asset`, `admin`
+#[contractevent]
+#[derive(Clone)]
+pub struct CircuitBreakerResetEvent {
+    /// Address of the asset whose breaker was reset.
+    #[topic]
+    pub asset: Address,
+    /// Admin who reset the breaker.
+    #[topic]
+    pub admin: Address,
+}
+
 /// Emitted when the oldest history entry for an asset is pruned to enforce `max_history_length`.
 ///
 /// Topics: `asset`

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -33,6 +33,9 @@ mod whitelisting;
 mod zk_verify;
 
 #[cfg(test)]
+mod circuit_breaker_tests;
+
+#[cfg(test)]
 mod cross_ref_tests;
 
 #[cfg(test)]
@@ -47,8 +50,8 @@ mod string_boundary_tests;
 pub use types::{
     AggregatePrice, AggregationMethod, Asset, BatchOperation, CrossReferenceResult, DataKey,
     ErrorCode, FinalityStatus, FinalizedPrice, HealthReport, MigrationState, OracleSources,
-    PendingBatch, PendingFinalityEntry, PriceCommit, PriceData, PriceEntry, PriceHistoryEntry,
-    PriceOverrideEntry, RelayerInfo, SourceHealthStatus, SubscriptionPlans,
+    PendingBatch, PendingFinalityEntry, PriceBounds, PriceCommit, PriceData, PriceEntry,
+    PriceHistoryEntry, PriceOverrideEntry, RelayerInfo, SourceHealthStatus, SubscriptionPlans,
 };
 
 use soroban_sdk::{
@@ -898,6 +901,42 @@ impl PriceOracleContract {
     /// `true` if registered; `false` otherwise.
     pub fn is_asset_registered(env: Env, asset: Address) -> bool {
         assets::is_asset_registered(&env, asset)
+    }
+
+    pub fn set_price_bounds(
+        env: Env,
+        asset: Address,
+        min_price: i128,
+        max_price: i128,
+        max_change_bps_per_ledger: u32,
+    ) {
+        reentrancy::enter(&env);
+        assets::set_price_bounds(&env, asset, min_price, max_price, max_change_bps_per_ledger);
+        reentrancy::exit(&env);
+    }
+
+    pub fn get_price_bounds(env: Env, asset: Address) -> PriceBounds {
+        assets::get_price_bounds(&env, asset)
+    }
+
+    pub fn pause_asset(env: Env, asset: Address) {
+        reentrancy::enter(&env);
+        assets::pause_asset(&env, asset);
+        reentrancy::exit(&env);
+    }
+
+    pub fn unpause_asset(env: Env, asset: Address) {
+        reentrancy::enter(&env);
+        assets::unpause_asset(&env, asset);
+        reentrancy::exit(&env);
+    }
+
+    pub fn is_asset_paused(env: Env, asset: Address) -> bool {
+        assets::is_asset_paused(&env, &asset)
+    }
+
+    pub fn is_circuit_breaker_tripped(env: Env, asset: Address) -> bool {
+        assets::is_circuit_breaker_tripped(&env, &asset)
     }
 
     // --- Prices ---

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -6,6 +6,9 @@ use crate::admin::{
     get_max_history_per_asset, get_min_sources_required, get_min_submission_interval,
     get_timestamp_threshold,
 };
+use crate::assets::{
+    get_price_bounds, is_asset_paused, is_circuit_breaker_tripped, trip_circuit_breaker,
+};
 use crate::events::{
     AggregationTriggeredEvent, EventLimitWarningEvent, HistoryPerAssetPrunedEvent,
     HistoryPrunedEvent, PriceAggregatedEvent, PriceOverrideExpiredEvent, PriceOverrideRemovedEvent,
@@ -15,14 +18,153 @@ use crate::events::{
 use crate::pause::check_not_paused;
 use crate::storage::{
     check_registered_asset, check_source, compute_confidence_bps, compute_mean, compute_median,
-    compute_trimmed_mean, read_oracle_sources, LEDGER_BUMP, LEDGER_THRESHOLD,
-    check_registered_asset, check_source, compute_mean, compute_median, compute_trimmed_mean,
-    get_admin, is_subscribed, read_oracle_sources, LEDGER_BUMP, LEDGER_THRESHOLD,
+    compute_trimmed_mean, get_admin, is_subscribed, read_oracle_sources, LEDGER_BUMP,
+    LEDGER_THRESHOLD,
 };
 use crate::types::{
     AggregatePrice, Asset, DataKey, ErrorCode, OracleSources, PriceData, PriceEntry,
     PriceHistoryEntry, PriceOverrideEntry,
 };
+
+fn build_candidate_aggregate(
+    env: &Env,
+    asset: &Address,
+    source: &Address,
+    price: i128,
+    timestamp: u64,
+    decimals: u32,
+) -> Option<AggregatePrice> {
+    let min_required = get_min_sources_required(env);
+    let oracle_sources: OracleSources = read_oracle_sources(env);
+    let total_sources = oracle_sources.sources.len();
+
+    let max_agg = get_max_aggregation_sources(env);
+    let selected_sources: Vec<Address> = if max_agg > 0 && total_sources > max_agg {
+        let hash_bytes = env.ledger().sequence().to_le_bytes();
+        let seed = u32::from_le_bytes(hash_bytes);
+        let mut selected: Vec<Address> = Vec::new(env);
+        let mut kept: u32 = 0;
+        for i in 0..total_sources {
+            let remaining = total_sources - i;
+            let needed = max_agg - kept;
+            let h = seed
+                .wrapping_mul(1664525u32)
+                .wrapping_add(i)
+                .wrapping_add(1013904223u32);
+            if needed >= remaining || (h % remaining) < needed {
+                selected.push_back(oracle_sources.sources.get_unchecked(i));
+                kept += 1;
+                if kept >= max_agg {
+                    break;
+                }
+            }
+        }
+        selected
+    } else {
+        oracle_sources.sources.clone()
+    };
+
+    let mut valid_prices: Vec<i128> = Vec::new(env);
+    let mut latest_timestamp: u64 = 0;
+    let mut contributing_sources: u32 = 0;
+
+    let selected_count = selected_sources.len();
+    for i in 0..selected_count {
+        let src = selected_sources.get_unchecked(i);
+        if src == *source {
+            if timestamp > latest_timestamp {
+                latest_timestamp = timestamp;
+            }
+            valid_prices.push_back(price);
+            contributing_sources += 1;
+            continue;
+        }
+
+        let sub_key = DataKey::Submission(asset.clone(), src.clone());
+        if let Some(entry_data) = env.storage().persistent().get::<_, PriceEntry>(&sub_key) {
+            if entry_data.timestamp > latest_timestamp {
+                latest_timestamp = entry_data.timestamp;
+            }
+            valid_prices.push_back(entry_data.price);
+            contributing_sources += 1;
+        }
+    }
+
+    if contributing_sources >= min_required && !valid_prices.is_empty() {
+        let method = get_aggregation_method(env);
+        let aggregated_price = match method {
+            0 => compute_median(&valid_prices),
+            1 => compute_mean(&valid_prices),
+            2 => compute_trimmed_mean(&valid_prices, 10),
+            _ => compute_median(&valid_prices),
+        };
+        Some(AggregatePrice {
+            price: aggregated_price,
+            timestamp: latest_timestamp,
+            num_sources: contributing_sources,
+            decimals,
+            is_override: false,
+        })
+    } else {
+        None
+    }
+}
+
+fn validate_price_submission(
+    env: &Env,
+    asset: &Address,
+    source: &Address,
+    price: i128,
+    timestamp: u64,
+    decimals: u32,
+) {
+    let bounds = get_price_bounds(env, asset.clone());
+    if price < bounds.min_price || price > bounds.max_price {
+        panic_with_error!(env, ErrorCode::PriceOutOfBounds);
+    }
+
+    if is_asset_paused(env, asset) || is_circuit_breaker_tripped(env, asset) {
+        panic_with_error!(env, ErrorCode::AssetPaused);
+    }
+
+    if bounds.max_change_bps_per_ledger > 0 {
+        let prev_aggregate: AggregatePrice = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Aggregate(asset.clone()))
+            .unwrap_or(AggregatePrice {
+                price: 0,
+                timestamp: 0,
+                num_sources: 0,
+                decimals,
+                is_override: false,
+            });
+
+        if prev_aggregate.price > 0 {
+            if let Some(candidate) =
+                build_candidate_aggregate(env, asset, source, price, timestamp, decimals)
+            {
+                let diff = if candidate.price > prev_aggregate.price {
+                    candidate.price - prev_aggregate.price
+                } else {
+                    prev_aggregate.price - candidate.price
+                };
+                let change_bps = diff.saturating_mul(10_000i128) / prev_aggregate.price;
+                if change_bps > bounds.max_change_bps_per_ledger as i128 {
+                    trip_circuit_breaker(
+                        env,
+                        asset.clone(),
+                        prev_aggregate.price,
+                        candidate.price,
+                        change_bps,
+                        bounds.max_change_bps_per_ledger,
+                    );
+                    panic_with_error!(env, ErrorCode::CircuitBreakerTripped);
+                }
+            }
+        }
+    }
+}
 
 /// Submits prices for multiple assets in a single atomic transaction.
 ///
@@ -63,10 +205,7 @@ pub fn submit_prices(env: &Env, source: Address, asset_prices: Vec<(Address, i12
             panic_with_error!(env, ErrorCode::InvalidPrice);
         }
 
-        let min_price = crate::assets::get_min_price(env, asset.clone());
-        if price < min_price {
-            panic_with_error!(env, ErrorCode::PriceBelowMinimum);
-        }
+        validate_price_submission(env, asset, &source, price, timestamp, decimals);
 
         if timestamp > ledger_time.saturating_add(threshold) {
             crate::sources::record_invalid_submission(env, source.clone());
@@ -388,12 +527,8 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
         panic_with_error!(env, ErrorCode::InvalidPrice);
     }
 
-    let min_price = crate::assets::get_min_price(env, asset.clone());
-    if price < min_price {
-        panic_with_error!(env, ErrorCode::PriceBelowMinimum);
-    }
-
     let ledger_time = env.ledger().timestamp();
+    validate_price_submission(env, &asset, &source, price, timestamp, get_decimals(env));
     let threshold = get_timestamp_threshold(env);
     if timestamp > ledger_time.saturating_add(threshold) {
         crate::sources::record_invalid_submission(env, source.clone());
@@ -425,6 +560,51 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
     .publish(env);
 
     aggregate_asset(env, &asset, current_ledger, decimals);
+}
+
+fn compute_twap_fallback(env: &Env, asset: &Address) -> Option<AggregatePrice> {
+    let current_ledger = env.ledger().sequence();
+    let max_history = get_max_history_length(env).max(5);
+    let decimals = get_decimals(env);
+    let mut total_weighted_price: i128 = 0;
+    let mut total_weight: u64 = 0;
+    let mut count: u32 = 0;
+
+    let start_ledger = current_ledger.saturating_sub(max_history);
+    let mut ledger = current_ledger;
+    loop {
+        let hist_key = DataKey::PriceHistory(asset.clone(), ledger);
+        if let Some(entry) = env
+            .storage()
+            .temporary()
+            .get::<_, PriceHistoryEntry>(&hist_key)
+        {
+            let weight = (ledger - start_ledger).max(1) as u64;
+            total_weighted_price =
+                total_weighted_price.saturating_add(entry.price.saturating_mul(weight as i128));
+            total_weight = total_weight.saturating_add(weight);
+            count += 1;
+        }
+        if ledger == start_ledger {
+            break;
+        }
+        if ledger == 0 {
+            break;
+        }
+        ledger -= 1;
+    }
+
+    if count == 0 || total_weight == 0 {
+        return None;
+    }
+
+    Some(AggregatePrice {
+        price: total_weighted_price / total_weight as i128,
+        timestamp: env.ledger().timestamp(),
+        num_sources: 0,
+        decimals,
+        is_override: false,
+    })
 }
 
 pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePrice> {
@@ -474,6 +654,13 @@ pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePri
             .publish(env);
             env.storage().persistent().remove(&override_key);
         }
+    }
+
+    if is_circuit_breaker_tripped(env, &asset) {
+        return compute_twap_fallback(env, &asset).or_else(|| {
+            let key = DataKey::Aggregate(asset.clone());
+            env.storage().persistent().get(&key)
+        });
     }
 
     let key = DataKey::Aggregate(asset.clone());
@@ -1280,7 +1467,13 @@ fn _compute_commit_hash(
 ///
 /// Skips `source.require_auth()` and pause check — callers are responsible
 /// for performing those checks before invoking this function.
-pub fn submit_price_internal(env: &Env, source: Address, asset: Address, price: i128, timestamp: u64) {
+pub fn submit_price_internal(
+    env: &Env,
+    source: Address,
+    asset: Address,
+    price: i128,
+    timestamp: u64,
+) {
     check_source(env, &source);
     check_registered_asset(env, &asset);
 

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -96,6 +96,16 @@ pub enum DataKey {
     AssetMetadata(Address),
     /// Optional minimum accepted price (`i128`) for a registered asset.
     AssetMinPrice(Address),
+    /// Per-asset price bounds applied to new submissions.
+    AssetPriceBounds(Address),
+    /// Whether an asset has been explicitly paused by the admin.
+    AssetPauseFlag(Address),
+    /// Whether the circuit breaker has tripped for an asset.
+    AssetCircuitBreakerTripped(Address),
+    /// Sequence counter for circuit-breaker event log entries.
+    AssetCircuitBreakerLogCount(Address),
+    /// Append-only circuit-breaker event log entry.
+    AssetCircuitBreakerLog(Address, u32),
     /// Configurable maximum number of assets that can be registered.
     MaxAssets,
 
@@ -305,6 +315,19 @@ pub struct PriceEntry {
     pub ledger_timestamp: u64,
 }
 
+/// Aggregated price bounds applied to an asset before a submission is accepted.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct PriceBounds {
+    /// Minimum accepted price for the asset.
+    pub min_price: i128,
+    /// Maximum accepted price for the asset.
+    pub max_price: i128,
+    /// Maximum allowed percentage change (in basis points) between the previous aggregate
+    /// and the candidate aggregate in a single ledger.
+    pub max_change_bps_per_ledger: u32,
+}
+
 /// An aggregated price computed from multiple oracle sources for a specific asset.
 ///
 /// Stored under [`DataKey::Aggregate`] and updated on every [`PriceEntry`] submission
@@ -321,6 +344,25 @@ pub struct AggregatePrice {
     /// Decimal precision applied to `price`.
     pub decimals: u32,
     pub is_override: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CircuitBreakerEventEntry {
+    /// Address of the asset affected by the breaker trip.
+    pub asset: Address,
+    /// Previous aggregate price before the candidate update.
+    pub previous_price: i128,
+    /// Candidate aggregate price that would have been published.
+    pub candidate_price: i128,
+    /// Percentage change in basis points that triggered the breaker.
+    pub change_bps: u32,
+    /// Maximum allowed change in basis points per ledger.
+    pub max_change_bps: u32,
+    /// Ledger where the breaker tripped.
+    pub ledger: u32,
+    /// Unix timestamp of the breaker trip.
+    pub timestamp: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.0"
 targets = ["wasm32v1-none"]


### PR DESCRIPTION
This PR implements programmatic price bounds and circuit breaker protection for the price oracle.

Changes Made

* Added configurable price bounds (`min_price`, `max_price`, `max_change_bps_per_ledger`) for registered assets.
* Rejects price submissions outside the configured price bounds.
* Introduced circuit breaker logic to detect excessive aggregate price changes between ledgers.
* Pauses affected assets when the circuit breaker is triggered.
* Emits emergency events for circuit breaker activations.
* Added append-only circuit breaker event logging.
* Added admin functionality to update price bounds and manually unpause assets.
* Added unit tests covering the new functionality.

For Testing

* Added circuit breaker unit tests.
* Verified existing tests continue to pass.


closes #183 
