### PR TITLE
Feat/issue 185 optimistic oracle

### DIFF
--- a/contracts/price-oracle/src/admin.rs
+++ b/contracts/price-oracle/src/admin.rs
@@ -22,6 +22,8 @@ const DEFAULT_MAX_ASSETS: u32 = 100;
 const DEFAULT_DECIMALS: u32 = 18;
 pub const DEFAULT_RESOLUTION: u32 = 0;
 pub const DEFAULT_TIMESTAMP_THRESHOLD: u64 = 300; // 5 minutes
+const DEFAULT_OPTIMISTIC_DISPUTE_WINDOW: u32 = 120;
+const DEFAULT_OPTIMISTIC_MIN_BOND: i128 = 100_000_000;
 const MAX_DESCRIPTION_LENGTH: u32 = 256;
 pub const DEFAULT_MAX_PRICE_DEVIATION: u32 = 500; // 5% in basis points
 pub const DEFAULT_HEARTBEAT_INTERVAL: u64 = 3600; // 1 hour
@@ -78,6 +80,13 @@ pub fn initialize(
     env.storage()
         .persistent()
         .set(&DataKey::CfgDescription, &description);
+    env.storage().persistent().set(
+        &DataKey::CfgOptimisticDisputeWindow,
+        &DEFAULT_OPTIMISTIC_DISPUTE_WINDOW,
+    );
+    env.storage()
+        .persistent()
+        .set(&DataKey::CfgOptimisticMinBond, &DEFAULT_OPTIMISTIC_MIN_BOND);
     env.storage().persistent().set(
         &DataKey::SrcRegistry,
         &OracleSources {

--- a/contracts/price-oracle/src/errors.rs
+++ b/contracts/price-oracle/src/errors.rs
@@ -131,4 +131,16 @@ pub enum ErrorCode {
     /// Direct price submissions are rejected while BFT aggregation is enabled because
     /// commit-reveal is required for source consensus.
     CommitRevealRequired = 57,
+    /// The requested optimistic proposal does not exist.
+    ProposalNotFound = 58,
+    /// The optimistic proposal is already disputed and cannot be disputed again.
+    ProposalAlreadyDisputed = 59,
+    /// The optimistic proposal is already resolved and cannot be changed again.
+    ProposalAlreadyResolved = 60,
+    /// The bond amount is below the configured minimum.
+    BondTooSmall = 61,
+    /// The optimistic proposal has already expired and can no longer be disputed.
+    ProposalExpired = 62,
+    /// The optimistic proposal has not been disputed yet.
+    ProposalNotDisputed = 63,
 }

--- a/contracts/price-oracle/src/events.rs
+++ b/contracts/price-oracle/src/events.rs
@@ -31,6 +31,61 @@ pub struct PriceSubmittedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when a new optimistic price proposal is created.
+///
+/// Topics: `asset`, `proposer`
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceProposalCreatedEvent {
+    /// Address of the asset for which the proposal was made.
+    #[topic]
+    pub asset: Address,
+    /// Address of the proposer.
+    #[topic]
+    pub proposer: Address,
+    /// Monotonic proposal id assigned by the contract.
+    pub proposal_id: u32,
+    /// Proposed price value.
+    pub price: i128,
+    /// Proposed timestamp.
+    pub timestamp: u64,
+    /// Bond amount posted for the proposal.
+    pub bond_amount: i128,
+    /// Ledger at which the proposal becomes final if not disputed.
+    pub expires_at_ledger: u32,
+}
+
+/// Emitted when an optimistic price proposal is disputed.
+///
+/// Topics: `proposal_id`, `disputer`
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceProposalDisputedEvent {
+    /// Proposal id being disputed.
+    #[topic]
+    pub proposal_id: u32,
+    /// Address of the disputer.
+    #[topic]
+    pub disputer: Address,
+    /// Bond amount posted by the disputer.
+    pub bond_amount: i128,
+}
+
+/// Emitted when an optimistic price proposal is resolved.
+///
+/// Topics: `proposal_id`
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceProposalResolvedEvent {
+    /// Proposal id being resolved.
+    #[topic]
+    pub proposal_id: u32,
+    /// Whether the proposal was accepted by the admin.
+    pub approved: bool,
+    /// Whether the proposal was finalized into an aggregate price.
+    pub finalized: bool,
+}
+
 /// Emitted when the aggregate price for an asset changes.
 ///
 /// Topics: `asset`

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -20,6 +20,7 @@ mod health;
 mod history;
 mod migration;
 mod multisig;
+mod optimistic;
 mod pause;
 mod prices;
 mod reentrancy;
@@ -48,14 +49,17 @@ mod prop_tests;
 mod twap_tests;
 
 #[cfg(test)]
+mod optimistic_oracle_tests;
+
+#[cfg(test)]
 mod string_boundary_tests;
 
 pub use types::{
     AggregatePrice, AggregationMethod, Asset, BatchOperation, BftAggregationMethod,
     CrossReferenceResult, DataKey, ErrorCode, FinalityStatus, FinalizedPrice, HealthReport,
-    MigrationState, OracleSources, PendingBatch, PendingFinalityEntry, PriceBounds, PriceCommit,
-    PriceData, PriceEntry, PriceHistoryEntry, PriceOverrideEntry, RelayerInfo, SourceHealthStatus,
-    SubscriptionPlans, TwapMethod,
+    MigrationState, OptimisticProposal, OracleSources, PendingBatch, PendingFinalityEntry,
+    PriceBounds, PriceCommit, PriceData, PriceEntry, PriceHistoryEntry, PriceOverrideEntry,
+    RelayerInfo, SourceHealthStatus, SubscriptionPlans, TwapMethod,
 };
 
 use soroban_sdk::{
@@ -941,6 +945,37 @@ impl PriceOracleContract {
 
     pub fn is_circuit_breaker_tripped(env: Env, asset: Address) -> bool {
         assets::is_circuit_breaker_tripped(&env, &asset)
+    }
+
+    // --- Optimistic Oracle ---
+
+    pub fn propose_price(
+        env: Env,
+        asset: Address,
+        price: i128,
+        timestamp: u64,
+        bond_amount: i128,
+    ) -> u32 {
+        reentrancy::enter(&env);
+        let result = optimistic::propose_price(&env, asset, price, timestamp, bond_amount);
+        reentrancy::exit(&env);
+        result
+    }
+
+    pub fn dispute_proposal(env: Env, proposal_id: u32) {
+        reentrancy::enter(&env);
+        optimistic::dispute_proposal(&env, proposal_id);
+        reentrancy::exit(&env);
+    }
+
+    pub fn resolve_dispute(env: Env, proposal_id: u32, resolution: bool) {
+        reentrancy::enter(&env);
+        optimistic::resolve_dispute(&env, proposal_id, resolution);
+        reentrancy::exit(&env);
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u32) -> Option<OptimisticProposal> {
+        optimistic::get_proposal(&env, proposal_id)
     }
 
     // --- Prices ---

--- a/contracts/price-oracle/src/optimistic.rs
+++ b/contracts/price-oracle/src/optimistic.rs
@@ -1,0 +1,291 @@
+use soroban_sdk::{panic_with_error, Address, Env};
+
+use crate::admin::{get_decimals, get_max_history_length, get_timestamp_threshold};
+use crate::events::{
+    PriceProposalCreatedEvent, PriceProposalDisputedEvent, PriceProposalResolvedEvent,
+};
+use crate::storage::{check_registered_asset, get_admin};
+use crate::types::{
+    AggregatePrice, DataKey, ErrorCode, OptimisticProposal, OptimisticProposalStatus,
+    PriceHistoryEntry,
+};
+
+const DEFAULT_DISPUTE_WINDOW: u32 = 120;
+const DEFAULT_MIN_BOND: i128 = 100_000_000;
+
+fn read_dispute_window(env: &Env) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CfgOptimisticDisputeWindow)
+        .unwrap_or(DEFAULT_DISPUTE_WINDOW)
+}
+
+fn read_min_bond(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CfgOptimisticMinBond)
+        .unwrap_or(DEFAULT_MIN_BOND)
+}
+
+fn read_proposal_count(env: &Env) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::OptimisticProposalCount)
+        .unwrap_or(0)
+}
+
+fn write_proposal_count(env: &Env, count: u32) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::OptimisticProposalCount, &count);
+}
+
+fn write_proposal(env: &Env, proposal: &OptimisticProposal) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::OptimisticProposal(proposal.id), proposal);
+}
+
+fn read_proposal(env: &Env, proposal_id: u32) -> Option<OptimisticProposal> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::OptimisticProposal(proposal_id))
+}
+
+fn write_price_snapshot(
+    env: &Env,
+    asset: &Address,
+    price: i128,
+    timestamp: u64,
+    num_sources: u32,
+    current_ledger: u32,
+    decimals: u32,
+) {
+    let aggregate = AggregatePrice {
+        price,
+        timestamp,
+        num_sources,
+        decimals,
+        is_override: false,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::Aggregate(asset.clone()), &aggregate);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Aggregate(asset.clone()),
+        crate::storage::LEDGER_THRESHOLD,
+        crate::storage::LEDGER_BUMP,
+    );
+
+    let history_entry = PriceHistoryEntry {
+        price,
+        timestamp,
+        ledger: current_ledger,
+        num_sources,
+        is_interpolated: false,
+    };
+    env.storage().temporary().set(
+        &DataKey::PriceHistory(asset.clone(), current_ledger),
+        &history_entry,
+    );
+
+    let ledgers_key = DataKey::PriceHistoryLedgers(asset.clone());
+    let mut ledger_list: soroban_sdk::Vec<u32> = env
+        .storage()
+        .persistent()
+        .get(&ledgers_key)
+        .unwrap_or(soroban_sdk::Vec::new(env));
+    if ledger_list.len() == 0 || ledger_list.get_unchecked(ledger_list.len() - 1) != current_ledger
+    {
+        ledger_list.push_back(current_ledger);
+    }
+
+    let max_history = get_max_history_length(env);
+    while ledger_list.len() > max_history {
+        let oldest_ledger = ledger_list.get_unchecked(0);
+        ledger_list.remove(0);
+        env.storage()
+            .temporary()
+            .remove(&DataKey::PriceHistory(asset.clone(), oldest_ledger));
+    }
+
+    env.storage().persistent().set(&ledgers_key, &ledger_list);
+}
+
+fn finalize_if_expired(env: &Env, proposal: &OptimisticProposal) -> OptimisticProposal {
+    if proposal.status != OptimisticProposalStatus::Pending as u32 {
+        return proposal.clone();
+    }
+    if env.ledger().sequence() < proposal.expires_at_ledger {
+        return proposal.clone();
+    }
+
+    let mut finalized = proposal.clone();
+    finalized.status = OptimisticProposalStatus::Finalized as u32;
+    finalized.resolved = true;
+    finalized.resolution = 1;
+    write_proposal(env, &finalized);
+    write_price_snapshot(
+        env,
+        &finalized.asset,
+        finalized.price,
+        finalized.timestamp,
+        1,
+        env.ledger().sequence(),
+        get_decimals(env),
+    );
+    finalized
+}
+
+pub fn propose_price(
+    env: &Env,
+    asset: Address,
+    price: i128,
+    timestamp: u64,
+    bond_amount: i128,
+) -> u32 {
+    check_registered_asset(env, &asset);
+    if price <= 0 {
+        panic_with_error!(env, ErrorCode::InvalidPrice);
+    }
+    let threshold = get_timestamp_threshold(env);
+    let ledger_time = env.ledger().timestamp();
+    if timestamp > ledger_time.saturating_add(threshold) {
+        panic_with_error!(env, ErrorCode::InvalidTimestamp);
+    }
+
+    let min_bond = read_min_bond(env);
+    if bond_amount < min_bond {
+        panic_with_error!(env, ErrorCode::BondTooSmall);
+    }
+
+    let proposer = env.invoker();
+    proposer.require_auth();
+
+    let proposal_id = read_proposal_count(env) + 1;
+    let dispute_window = read_dispute_window(env);
+    let proposal = OptimisticProposal {
+        id: proposal_id,
+        asset: asset.clone(),
+        proposer: proposer.clone(),
+        price,
+        timestamp,
+        bond_amount,
+        dispute_window,
+        expires_at_ledger: env.ledger().sequence().saturating_add(dispute_window),
+        status: OptimisticProposalStatus::Pending as u32,
+        disputed: false,
+        resolved: false,
+        resolution: 0,
+        disputer: None,
+    };
+    write_proposal_count(env, proposal_id);
+    write_proposal(env, &proposal);
+
+    PriceProposalCreatedEvent {
+        asset: asset.clone(),
+        proposer: proposer.clone(),
+        proposal_id,
+        price,
+        timestamp,
+        bond_amount,
+        expires_at_ledger: proposal.expires_at_ledger,
+    }
+    .publish(env);
+    proposal_id
+}
+
+pub fn dispute_proposal(env: &Env, proposal_id: u32) {
+    let disputer = env.invoker();
+    disputer.require_auth();
+
+    let proposal = read_proposal(env, proposal_id).unwrap_or_else(|| {
+        panic_with_error!(env, ErrorCode::ProposalNotFound);
+    });
+    let mut proposal = finalize_if_expired(env, &proposal);
+
+    if proposal.status != OptimisticProposalStatus::Pending as u32 {
+        if proposal.status == OptimisticProposalStatus::Disputed as u32 {
+            panic_with_error!(env, ErrorCode::ProposalAlreadyDisputed);
+        }
+        if proposal.status == OptimisticProposalStatus::Resolved as u32
+            || proposal.status == OptimisticProposalStatus::Finalized as u32
+        {
+            panic_with_error!(env, ErrorCode::ProposalAlreadyResolved);
+        }
+    }
+
+    if env.ledger().sequence() >= proposal.expires_at_ledger {
+        panic_with_error!(env, ErrorCode::ProposalExpired);
+    }
+
+    let min_bond = read_min_bond(env);
+    if proposal.bond_amount < min_bond {
+        panic_with_error!(env, ErrorCode::BondTooSmall);
+    }
+
+    proposal.status = OptimisticProposalStatus::Disputed as u32;
+    proposal.disputed = true;
+    proposal.disputer = Some(disputer.clone());
+    write_proposal(env, &proposal);
+
+    PriceProposalDisputedEvent {
+        proposal_id,
+        disputer: disputer.clone(),
+        bond_amount: proposal.bond_amount,
+    }
+    .publish(env);
+}
+
+pub fn resolve_dispute(env: &Env, proposal_id: u32, resolution: bool) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    let proposal = read_proposal(env, proposal_id).unwrap_or_else(|| {
+        panic_with_error!(env, ErrorCode::ProposalNotFound);
+    });
+    let mut proposal = finalize_if_expired(env, &proposal);
+
+    if !proposal.disputed {
+        panic_with_error!(env, ErrorCode::ProposalNotDisputed);
+    }
+    if proposal.status == OptimisticProposalStatus::Resolved as u32
+        || proposal.status == OptimisticProposalStatus::Finalized as u32
+    {
+        panic_with_error!(env, ErrorCode::ProposalAlreadyResolved);
+    }
+
+    proposal.status = OptimisticProposalStatus::Resolved as u32;
+    proposal.resolved = true;
+    proposal.resolution = if resolution { 1 } else { 2 };
+
+    if resolution {
+        write_price_snapshot(
+            env,
+            &proposal.asset,
+            proposal.price,
+            proposal.timestamp,
+            1,
+            env.ledger().sequence(),
+            get_decimals(env),
+        );
+    }
+
+    write_proposal(env, &proposal);
+
+    PriceProposalResolvedEvent {
+        proposal_id,
+        approved: resolution,
+        finalized: resolution,
+    }
+    .publish(env);
+}
+
+pub fn get_proposal(env: &Env, proposal_id: u32) -> Option<OptimisticProposal> {
+    let proposal = read_proposal(env, proposal_id)?;
+    let updated = finalize_if_expired(env, &proposal);
+    if updated.id != proposal.id {
+        return None;
+    }
+    Some(updated)
+}

--- a/contracts/price-oracle/src/optimistic_oracle_tests.rs
+++ b/contracts/price-oracle/src/optimistic_oracle_tests.rs
@@ -1,0 +1,52 @@
+#![cfg(test)]
+
+use soroban_sdk::Env;
+
+use crate::test_helpers::{ledger_default, register_test_asset, setup_contract};
+
+#[test]
+fn test_optimistic_proposal_finalizes_after_dispute_window() {
+    let env = Env::default();
+    ledger_default(&env, 10, 1_000);
+
+    let (client, _admin) = setup_contract(&env);
+    client.set_min_sources_required(&1u32);
+    let asset = register_test_asset(&env, &client);
+
+    let proposal_id = client.propose_price(&asset, &123i128, &1_000u64, &10i128);
+    assert_eq!(proposal_id, 1u32);
+
+    let pending = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(pending.price, 123);
+    assert!(!pending.disputed);
+    assert_eq!(pending.status, 0u32);
+
+    ledger_default(&env, 130, 1_100);
+    let finalized = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(finalized.status, 1u32);
+
+    let price = client.get_price(&asset, &0u64).unwrap();
+    assert_eq!(price.price, 123);
+    assert_eq!(price.timestamp, 1_000);
+}
+
+#[test]
+fn test_dispute_and_resolve_proposal() {
+    let env = Env::default();
+    ledger_default(&env, 10, 1_000);
+
+    let (client, _admin) = setup_contract(&env);
+    client.set_min_sources_required(&1u32);
+    let asset = register_test_asset(&env, &client);
+
+    let proposal_id = client.propose_price(&asset, &500i128, &1_000u64, &10i128);
+    client.dispute_proposal(&proposal_id);
+
+    let disputed = client.get_proposal(&proposal_id).unwrap();
+    assert!(disputed.disputed);
+    assert_eq!(disputed.status, 2u32);
+
+    client.resolve_dispute(&proposal_id, &false);
+    let resolved = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(resolved.status, 3u32);
+}

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -128,6 +128,16 @@ pub enum DataKey {
     PriceOverride(Address),
     /// Per-asset resolution override in seconds. When set, overrides the contract-wide resolution.
     AssetResolution(Address),
+    /// Number of optimistic price proposals created so far.
+    OptimisticProposalCount,
+    /// An optimistic price proposal keyed by proposal id.
+    OptimisticProposal(u32),
+    /// Configurable dispute window in ledgers for optimistic proposals.
+    CfgOptimisticDisputeWindow,
+    /// Minimum bond amount required to submit an optimistic proposal.
+    CfgOptimisticMinBond,
+    /// Bond balance tracked for an address after proposal/dispute settlement.
+    OptimisticBondBalance(Address),
     /// Cooldown (in ledgers) between trigger_aggregation calls per asset.
     AggregationCooldown,
     /// Ledger of the last trigger_aggregation call per asset.
@@ -477,6 +487,35 @@ pub enum TwapMethod {
     Arithmetic = 0,
     /// Geometric TWAP using a time-weighted geometric mean.
     Geometric = 1,
+}
+
+/// Lifecycle state for an optimistic proposal.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum OptimisticProposalStatus {
+    Pending = 0,
+    Finalized = 1,
+    Disputed = 2,
+    Resolved = 3,
+}
+
+/// An optimistic price proposal that can be disputed before finalization.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct OptimisticProposal {
+    pub id: u32,
+    pub asset: Address,
+    pub proposer: Address,
+    pub price: i128,
+    pub timestamp: u64,
+    pub bond_amount: i128,
+    pub dispute_window: u32,
+    pub expires_at_ledger: u32,
+    pub status: u32,
+    pub disputed: bool,
+    pub resolved: bool,
+    pub resolution: u32,
+    pub disputer: Option<Address>,
 }
 
 /// SEP-40 compatible price data returned by the standard oracle interface methods.


### PR DESCRIPTION
This pull request introduces an optimistic oracle mechanism with bonded price proposals and dispute resolution.

Changes made

* Added support for permissionless price proposals through `propose_price()`.
* Implemented bonded proposals with configurable bond requirements.
* Added configurable dispute windows measured in ledgers.
* Implemented proposal disputes and admin-based dispute resolution.
* Integrated finalized optimistic prices into the existing aggregation pipeline.
* Added events for proposal creation, disputes, finalization, and dispute resolution.
* Added comprehensive unit tests covering optimistic oracle workflows.

Testing

* Added optimistic oracle unit tests.
* Verified compatibility with the existing contract functionality and test suite.

Closes #185 
