### PR TITLE
Add price freeze, paginated history, and notification preferences

### DIFF
--- a/contracts/price-oracle/src/errors.rs
+++ b/contracts/price-oracle/src/errors.rs
@@ -17,7 +17,8 @@ use soroban_sdk::contracterror;
 /// | 40–49  | Finality gadget (#188) |
 /// | 50–61  | Relayer & misc         |
 /// | 62–74  | Asset/price bounds     |
-/// | 75–99  | Advanced features      |
+/// | 75–98  | Advanced features      |
+/// | 99–102 | Freeze/pagination/notify (#223,#229,#243) |
 #[contracterror]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ErrorCode {
@@ -200,4 +201,14 @@ pub enum ErrorCode {
     ZkVkNotSet = 97,
     /// ZK invalid public signals.
     ZkInvalidPublicSignals = 98,
+
+    // ── 99–105: Freeze, pagination & notifications ────────────────────────────
+    /// The asset's price is currently frozen (#223).
+    PriceFrozen = 99,
+    /// The asset's price is not currently frozen (#223).
+    PriceNotFrozen = 100,
+    /// The requested pagination limit is `0` or exceeds the configured maximum (#229).
+    InvalidPageSize = 101,
+    /// A notification `channel` or `target` string exceeds the maximum allowed length (#243).
+    NotificationConfigInvalid = 102,
 }

--- a/contracts/price-oracle/src/events.rs
+++ b/contracts/price-oracle/src/events.rs
@@ -1914,3 +1914,41 @@ pub struct RateLimitTierChangedEvent {
 // Emitted when an invalid submission is recorded against a source (re-export from events).
 // Already defined elsewhere, but needed here as well.
 // Note: InvalidSubmissionRecordedEvent is already defined above; this is the canonical copy.
+
+/// Emitted when an admin freezes an asset's price during a market emergency (#223).
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceFrozenEvent {
+    #[topic]
+    pub asset: Address,
+    pub reason: String,
+    pub price: i128,
+    pub frozen_at_ledger: u32,
+}
+
+/// Emitted when an admin unfreezes a previously frozen asset (#223).
+#[contractevent]
+#[derive(Clone)]
+pub struct PriceUnfrozenEvent {
+    #[topic]
+    pub asset: Address,
+    pub unfrozen_at_ledger: u32,
+}
+
+/// Emitted when an admin registers a notification preference for an event type (#243).
+#[contractevent]
+#[derive(Clone)]
+pub struct NotifPrefSetEvent {
+    #[topic]
+    pub event_type: u32,
+    pub channel: String,
+    pub target: String,
+}
+
+/// Emitted when an admin clears all notification preferences for an event type (#243).
+#[contractevent]
+#[derive(Clone)]
+pub struct NotifPrefsClearedEvent {
+    #[topic]
+    pub event_type: u32,
+}

--- a/contracts/price-oracle/src/freeze.rs
+++ b/contracts/price-oracle/src/freeze.rs
@@ -1,0 +1,104 @@
+//! Price freeze mechanism for market emergencies (#223)
+//!
+//! Lets the admin freeze an asset's aggregate price during a market disruption
+//! event (flash crash, exchange hack, etc). While frozen, `get_price` returns the
+//! frozen snapshot regardless of new activity, and price submissions are rejected
+//! until the asset is explicitly unfrozen.
+
+use soroban_sdk::{panic_with_error, Address, Env, String};
+
+use crate::events::{PriceFrozenEvent, PriceUnfrozenEvent};
+use crate::storage::{check_registered_asset, get_admin};
+use crate::types::{AggregatePrice, DataKey, ErrorCode, FrozenPrice};
+
+/// Freezes the current aggregate price for an asset, preventing further updates.
+///
+/// # Errors
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+/// * [`ErrorCode::AssetNotRegistered`] — asset is not registered.
+/// * [`ErrorCode::ReasonTooLong`] — reason exceeds 256 characters.
+/// * [`ErrorCode::PriceFrozen`] — asset is already frozen.
+/// * [`ErrorCode::NoData`] — asset has no aggregate price to freeze yet.
+pub fn freeze_price(env: &Env, asset: Address, reason: String) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    check_registered_asset(env, &asset);
+
+    if reason.len() > 256 {
+        panic_with_error!(env, ErrorCode::ReasonTooLong);
+    }
+
+    let key = DataKey::FrozenPrice(asset.clone());
+    if env.storage().persistent().has(&key) {
+        panic_with_error!(env, ErrorCode::PriceFrozen);
+    }
+
+    let aggregate: AggregatePrice = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Aggregate(asset.clone()))
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::NoData));
+
+    let current_ledger = env.ledger().sequence();
+    let frozen = FrozenPrice {
+        price: aggregate.price,
+        timestamp: aggregate.timestamp,
+        decimals: aggregate.decimals,
+        reason: reason.clone(),
+        frozen_at_ledger: current_ledger,
+    };
+    env.storage().persistent().set(&key, &frozen);
+
+    PriceFrozenEvent {
+        asset,
+        reason,
+        price: aggregate.price,
+        frozen_at_ledger: current_ledger,
+    }
+    .publish(env);
+}
+
+/// Unfreezes a previously frozen asset, resuming normal price updates.
+///
+/// # Errors
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+/// * [`ErrorCode::PriceNotFrozen`] — asset is not currently frozen.
+pub fn unfreeze_price(env: &Env, asset: Address) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    let key = DataKey::FrozenPrice(asset.clone());
+    if !env.storage().persistent().has(&key) {
+        panic_with_error!(env, ErrorCode::PriceNotFrozen);
+    }
+    env.storage().persistent().remove(&key);
+
+    PriceUnfrozenEvent {
+        asset,
+        unfrozen_at_ledger: env.ledger().sequence(),
+    }
+    .publish(env);
+}
+
+/// Returns whether an asset's price is currently frozen.
+pub fn is_price_frozen(env: &Env, asset: Address) -> bool {
+    env.storage().persistent().has(&DataKey::FrozenPrice(asset))
+}
+
+/// Returns the frozen price snapshot for an asset, if one is active.
+pub fn get_frozen_price(env: &Env, asset: Address) -> Option<FrozenPrice> {
+    env.storage().persistent().get(&DataKey::FrozenPrice(asset))
+}
+
+/// Panics with [`ErrorCode::PriceFrozen`] if `asset` is currently frozen.
+///
+/// Called by every price-submission entry point to enforce the freeze.
+pub fn check_not_frozen(env: &Env, asset: &Address) {
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::FrozenPrice(asset.clone()))
+    {
+        panic_with_error!(env, ErrorCode::PriceFrozen);
+    }
+}

--- a/contracts/price-oracle/src/history.rs
+++ b/contracts/price-oracle/src/history.rs
@@ -113,3 +113,62 @@ pub fn get_historical_prices(
     }
     entries
 }
+
+/// Maximum page size accepted by `get_historical_prices_paginated` (#229).
+pub const MAX_PAGE_SIZE: u32 = 50;
+
+/// Returns a cursor-paginated page of historical price entries for an asset.
+///
+/// `cursor` is the ledger sequence number to start from, inclusive (pass `0` to
+/// start at the beginning). `limit` must be in `1..=MAX_PAGE_SIZE`. Entries are
+/// returned in ascending ledger order, correctly skipping over gaps where no
+/// snapshot was recorded.
+///
+/// Returns `(entries, next_cursor)`: `next_cursor` is `Some(ledger)` to pass as
+/// the next page's `cursor`, or `None` once every recorded entry has been read.
+///
+/// # Errors
+/// * [`ErrorCode::AssetNotRegistered`] — if `asset` is not registered.
+/// * [`ErrorCode::InvalidPageSize`] — if `limit` is `0` or exceeds `MAX_PAGE_SIZE`.
+pub fn get_historical_prices_paginated(
+    env: &Env,
+    asset: Address,
+    cursor: u32,
+    limit: u32,
+) -> (Vec<PriceHistoryEntry>, Option<u32>) {
+    check_registered_asset(env, &asset);
+    if limit == 0 || limit > MAX_PAGE_SIZE {
+        panic_with_error!(env, ErrorCode::InvalidPageSize);
+    }
+
+    let ledgers_key = DataKey::PriceHistoryLedgers(asset.clone());
+    let ledger_list: Vec<u32> = env
+        .storage()
+        .persistent()
+        .get(&ledgers_key)
+        .unwrap_or(Vec::new(env));
+
+    let mut entries: Vec<PriceHistoryEntry> = Vec::new(env);
+    let mut next_cursor: Option<u32> = None;
+
+    for i in 0..ledger_list.len() {
+        let l = ledger_list.get_unchecked(i);
+        if l < cursor {
+            continue;
+        }
+        if entries.len() >= limit {
+            next_cursor = Some(l);
+            break;
+        }
+        let key = DataKey::PriceHistory(asset.clone(), l);
+        if env.storage().temporary().has(&key) {
+            let entry: PriceHistoryEntry = env.storage().temporary().get(&key).unwrap();
+            env.storage()
+                .temporary()
+                .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+            entries.push_back(entry);
+        }
+    }
+
+    (entries, next_cursor)
+}

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -51,6 +51,8 @@ mod zk_verify;
 mod audit_log;
 mod rbac;
 mod emergency_pause;
+mod freeze;
+mod notifications;
 
 #[cfg(test)]
 mod circuit_breaker_tests;
@@ -94,6 +96,7 @@ pub use types::{
     SourceGovernance, SourceProposal,
     SourceGeoMetadata, DecentralizationReport,
     GasRecord, StorageTtlEntry,
+    FrozenPrice, NotificationPreference,
 };
 
 
@@ -1609,6 +1612,111 @@ impl PriceOracleContract {
         let result = history::get_historical_prices(&env, asset, start_ledger, end_ledger);
         exit_reentrancy_guard(&env);
         result
+    }
+
+    /// Returns a cursor-paginated page of historical price entries for an asset (#229).
+    ///
+    /// `cursor` is the ledger sequence number to start from (inclusive); pass `0` for the
+    /// first page. `limit` is capped at `history::MAX_PAGE_SIZE` (50).
+    ///
+    /// # Returns
+    ///
+    /// `(entries, next_cursor)` — `next_cursor` is `Some(ledger)` to request the next page,
+    /// or `None` once all recorded entries have been returned.
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::AssetNotRegistered`] — if `asset` is not registered.
+    /// * [`ErrorCode::InvalidPageSize`] — if `limit` is `0` or exceeds the maximum page size.
+    pub fn get_historical_prices_paginated(
+        env: Env,
+        asset: Address,
+        cursor: u32,
+        limit: u32,
+    ) -> (Vec<PriceHistoryEntry>, Option<u32>) {
+        enter_reentrancy_guard(&env);
+        let result = history::get_historical_prices_paginated(&env, asset, cursor, limit);
+        exit_reentrancy_guard(&env);
+        result
+    }
+
+    // --- Price freeze (#223) ---
+
+    /// Freezes the current aggregate price for an asset during a market emergency.
+    ///
+    /// While frozen, `get_price` returns the frozen snapshot and price submissions for
+    /// the asset are rejected until `unfreeze_price` is called.
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::NotAuthorized`] — if the caller is not the admin.
+    /// * [`ErrorCode::AssetNotRegistered`] — if `asset` is not registered.
+    /// * [`ErrorCode::ReasonTooLong`] — if `reason` exceeds 256 characters.
+    /// * [`ErrorCode::PriceFrozen`] — if the asset is already frozen.
+    /// * [`ErrorCode::NoData`] — if the asset has no aggregate price yet.
+    pub fn freeze_price(env: Env, asset: Address, reason: String) {
+        freeze::freeze_price(&env, asset, reason);
+    }
+
+    /// Unfreezes a previously frozen asset, resuming normal price updates.
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::NotAuthorized`] — if the caller is not the admin.
+    /// * [`ErrorCode::PriceNotFrozen`] — if the asset is not currently frozen.
+    pub fn unfreeze_price(env: Env, asset: Address) {
+        freeze::unfreeze_price(&env, asset);
+    }
+
+    /// Returns whether an asset's price is currently frozen.
+    pub fn is_price_frozen(env: Env, asset: Address) -> bool {
+        freeze::is_price_frozen(&env, asset)
+    }
+
+    // --- Notification preferences (#243) ---
+
+    /// Registers an admin notification preference for a given event type.
+    ///
+    /// `event_type` is a caller-defined discriminant (e.g. matching an event-indexing
+    /// scheme); `channel` identifies the notification kind (e.g. `"webhook"`, `"email"`)
+    /// and `target` is the channel-specific destination. Dispatch is performed by an
+    /// off-chain relayer service watching contract events — this only stores the
+    /// preference.
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::NotAuthorized`] — if the caller is not the admin.
+    /// * [`ErrorCode::NotificationConfigInvalid`] — if `channel` or `target` exceeds 256 chars.
+    pub fn set_notification_preference(
+        env: Env,
+        event_type: u32,
+        channel: String,
+        target: String,
+    ) {
+        notifications::set_notification_preference(&env, event_type, channel, target);
+    }
+
+    /// Returns all notification preferences registered for a given event type.
+    pub fn list_notification_preferences(
+        env: Env,
+        event_type: u32,
+    ) -> Vec<NotificationPreference> {
+        notifications::list_notification_preferences(&env, event_type)
+    }
+
+    /// Returns every event-type discriminant that currently has at least one
+    /// notification preference registered.
+    pub fn list_notification_event_types(env: Env) -> Vec<u32> {
+        notifications::list_notification_event_types(&env)
+    }
+
+    /// Clears all notification preferences registered for a given event type.
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::NotAuthorized`] — if the caller is not the admin.
+    pub fn clear_notification_preferences(env: Env, event_type: u32) {
+        notifications::clear_notification_preferences(&env, event_type);
     }
 
     /// Enables or disables linear interpolation for `get_historical_price` queries.

--- a/contracts/price-oracle/src/notifications.rs
+++ b/contracts/price-oracle/src/notifications.rs
@@ -1,0 +1,114 @@
+//! Admin notification preference system (#243)
+//!
+//! Lets the admin register off-chain notification targets (webhook URLs, email
+//! addresses, etc) per event type. This module only stores and exposes the
+//! preferences — an off-chain relayer service watches contract events and
+//! dispatches the actual notifications to the registered targets.
+
+use soroban_sdk::{panic_with_error, Env, String, Vec};
+
+use crate::events::{NotifPrefSetEvent, NotifPrefsClearedEvent};
+use crate::storage::get_admin;
+use crate::types::{DataKey, ErrorCode, NotificationPreference};
+
+const MAX_STRING_LEN: u32 = 256;
+
+/// Registers a notification preference for a given event type.
+///
+/// Idempotent: registering the same `(event_type, channel, target)` twice does
+/// not create a duplicate entry.
+///
+/// # Errors
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+/// * [`ErrorCode::NotificationConfigInvalid`] — `channel` or `target` exceeds 256 chars.
+pub fn set_notification_preference(env: &Env, event_type: u32, channel: String, target: String) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    if channel.len() > MAX_STRING_LEN || target.len() > MAX_STRING_LEN {
+        panic_with_error!(env, ErrorCode::NotificationConfigInvalid);
+    }
+
+    let key = DataKey::NotificationPrefs(event_type);
+    let mut prefs: Vec<NotificationPreference> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+
+    let already_exists = prefs
+        .iter()
+        .any(|p| p.channel == channel && p.target == target);
+
+    if !already_exists {
+        prefs.push_back(NotificationPreference {
+            event_type,
+            channel: channel.clone(),
+            target: target.clone(),
+        });
+        env.storage().persistent().set(&key, &prefs);
+
+        let types_key = DataKey::NotificationEventTypes;
+        let mut types: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&types_key)
+            .unwrap_or(Vec::new(env));
+        if !types.contains(&event_type) {
+            types.push_back(event_type);
+            env.storage().persistent().set(&types_key, &types);
+        }
+    }
+
+    NotifPrefSetEvent {
+        event_type,
+        channel,
+        target,
+    }
+    .publish(env);
+}
+
+/// Returns all notification preferences registered for a specific event type.
+pub fn list_notification_preferences(env: &Env, event_type: u32) -> Vec<NotificationPreference> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::NotificationPrefs(event_type))
+        .unwrap_or(Vec::new(env))
+}
+
+/// Returns every event-type discriminant that currently has at least one preference set.
+pub fn list_notification_event_types(env: &Env) -> Vec<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::NotificationEventTypes)
+        .unwrap_or(Vec::new(env))
+}
+
+/// Clears all notification preferences registered for a given event type.
+///
+/// # Errors
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+pub fn clear_notification_preferences(env: &Env, event_type: u32) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::NotificationPrefs(event_type));
+
+    let types_key = DataKey::NotificationEventTypes;
+    let types: Vec<u32> = env
+        .storage()
+        .persistent()
+        .get(&types_key)
+        .unwrap_or(Vec::new(env));
+    let mut new_types = Vec::new(env);
+    for t in types.iter() {
+        if t != event_type {
+            new_types.push_back(t);
+        }
+    }
+    env.storage().persistent().set(&types_key, &new_types);
+
+    NotifPrefsClearedEvent { event_type }.publish(env);
+}

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -314,6 +314,7 @@ pub fn submit_prices(env: &Env, source: Address, asset_prices: Vec<(Address, i12
     for i in 0..asset_prices.len() {
         let (ref asset, price, timestamp) = asset_prices.get_unchecked(i);
         check_registered_asset(env, asset);
+        crate::freeze::check_not_frozen(env, asset);
         check_source_asset(env, &source, asset);
 
         if price <= 0 {
@@ -756,6 +757,7 @@ pub fn submit_price(env: &Env, source: Address, asset: Address, price: i128, tim
     source.require_auth();
     check_source(env, &source);
     check_registered_asset(env, &asset);
+    crate::freeze::check_not_frozen(env, &asset);
     check_source_asset(env, &source, &asset);
     check_source_asset(env, &source, &asset);
     enforce_commit_reveal_for_bft(env);
@@ -830,6 +832,7 @@ pub fn submit_price_with_volume(
     source.require_auth();
     check_source(env, &source);
     check_registered_asset(env, &asset);
+    crate::freeze::check_not_frozen(env, &asset);
     check_source_asset(env, &source, &asset);
     enforce_commit_reveal_for_bft(env);
 
@@ -1044,6 +1047,18 @@ pub fn get_price(env: &Env, asset: Address, max_age: u64) -> Option<AggregatePri
     check_registered_asset(env, &asset);
     let current_ledger = env.ledger().sequence();
     let ledger_time = env.ledger().timestamp();
+
+    // A freeze (#223) takes priority over overrides and the live aggregate: it
+    // locks the price in place regardless of any other activity.
+    if let Some(frozen) = crate::freeze::get_frozen_price(env, asset.clone()) {
+        return Some(AggregatePrice {
+            price: frozen.price,
+            timestamp: frozen.timestamp,
+            num_sources: 0,
+            decimals: frozen.decimals,
+            is_override: false,
+        });
+    }
 
     // Check for active price override
     let override_key = DataKey::PriceOverride(asset.clone());

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -457,6 +457,25 @@ pub enum DataKey {
     AuditEntryCount,
     /// Current audit log chain head hash (#239).
     AuditLogHead,
+
+    // -------------------------------------------------------------------------
+    // #223: Price freeze mechanism for market emergencies
+    // -------------------------------------------------------------------------
+    /// Frozen price snapshot for an asset, present only while frozen (#223).
+    FrozenPrice(Address),
+
+    // -------------------------------------------------------------------------
+    // #229: Cursor-paginated historical price queries
+    // -------------------------------------------------------------------------
+    // (no additional storage keys — pagination reuses `PriceHistoryLedgers`)
+
+    // -------------------------------------------------------------------------
+    // #243: Admin notification preference system
+    // -------------------------------------------------------------------------
+    /// Notification preferences registered for a given event-type discriminant (#243).
+    NotificationPrefs(u32),
+    /// Every event-type discriminant that currently has at least one preference (#243).
+    NotificationEventTypes,
 }
 
 
@@ -580,6 +599,39 @@ pub struct PriceHistoryEntry {
     /// `true` when this entry was produced by linear interpolation rather than a
     /// real submission. Consumers should treat interpolated values as estimates.
     pub is_interpolated: bool,
+}
+
+/// A frozen aggregate price snapshot, recorded when an admin freezes an asset
+/// during a market emergency (#223). While present, it takes priority over the
+/// live aggregate for `get_price` and blocks new submissions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct FrozenPrice {
+    /// The aggregate price at the moment of freezing, scaled by `10^decimals`.
+    pub price: i128,
+    /// Unix timestamp of the aggregate at the moment of freezing.
+    pub timestamp: u64,
+    /// Decimal precision in effect when the price was frozen.
+    pub decimals: u32,
+    /// Admin-supplied human-readable reason for the freeze.
+    pub reason: String,
+    /// Ledger sequence number at which the freeze was triggered.
+    pub frozen_at_ledger: u32,
+}
+
+/// An admin-configured off-chain notification target for a given event type (#243).
+///
+/// Dispatch happens off-chain: an external relayer service watches contract events
+/// and forwards them to the configured `channel`/`target` pairs registered here.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct NotificationPreference {
+    /// Event-type discriminant this preference applies to.
+    pub event_type: u32,
+    /// Notification channel kind (e.g. "webhook", "email").
+    pub channel: String,
+    /// Channel-specific target (URL, email address, etc).
+    pub target: String,
 }
 
 /// Gas usage record for the most-recent submit/aggregate operation.


### PR DESCRIPTION
## Summary

Closes #223, closes #228, closes #229, closes #243.

- **#223 — Price freeze mechanism**: adds `freeze_price(asset, reason)`, `unfreeze_price(asset)`, and `is_price_frozen(asset)`. While frozen, `get_price` returns the frozen snapshot (takes priority over overrides/live aggregate) and every price-submission entry point (`submit_price`, `submit_price_with_volume`, `submit_prices`) rejects updates with `PriceFrozen`. Freeze/unfreeze emit `PriceFrozenEvent`/`PriceUnfrozenEvent`.
- **#228 — Commit-reveal**: verified this is already fully implemented by the existing #187 commit-reveal module (`commit_price`, `reveal_price`, `reveal_prices_batch` in `prices.rs`, wired up in `lib.rs`, with a configurable reveal window and full lifecycle coverage in `commit_reveal_tests.rs`). No code changes were needed — closing as already satisfied.
- **#229 — Paginated historical price query**: adds `get_historical_prices_paginated(asset, cursor, limit) -> (Vec<PriceHistoryEntry>, Option<u32>)`. Cursor is the ledger sequence number (inclusive start), page size capped at 50 (`InvalidPageSize` if `0` or over the max), and it walks the existing per-asset ledger index so it correctly skips gaps.
- **#243 — Admin notification preferences**: adds a `NotificationPreference { event_type, channel, target }` struct plus `set_notification_preference`, `list_notification_preferences`, `list_notification_event_types`, and `clear_notification_preferences` admin endpoints. Storage only — dispatch is performed by an off-chain relayer service watching contract events, per the issue's design.

## Notes

- Per request, test suites were not added/run for this change.
- The `price-oracle` crate has pre-existing build issues on `main` (194 compiler errors, ~210 `cargo fmt` violations, e.g. duplicate struct fields, i128/u128 mismatches in `amm.rs`, missing `storage::enter_reentrancy_guard` export) that predate and are unrelated to this PR. I verified via a stashed baseline build that this PR introduces **zero new compile errors** on top of that baseline.
- Because of the above, the repo's pre-commit/pre-push hooks (which run `cargo fmt --check`, `clippy -D warnings`, and a release wasm build across the whole crate) currently fail for any commit regardless of content, so this PR was pushed with hooks skipped after confirming with the user.

## Test plan

- [ ] Fix the pre-existing `price-oracle` build errors on `main` so the crate compiles, then run `commit_reveal_tests.rs` and add lifecycle tests for freeze, pagination, and notification preferences.