### PR TITLE
Deployment verification, ABI docs, event schema registry, external adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,26 @@ jobs:
       - name: Run tests
         run: make test
 
+  abi-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli --version "^23"
+      - name: Generate ABI
+        run: ./scripts/generate-abi.sh
+      - name: Upload generated ABI
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-abi
+          path: docs/abi.json
+
   deny:
     runs-on: ubuntu-latest
     steps:

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -1,0 +1,42 @@
+# Contract ABI
+
+The Price Oracle contract's ABI (function signatures, parameter types, and
+struct/enum definitions) is generated directly from the contract's compiled
+WASM, so it can never drift from the deployed interface.
+
+## Machine-readable ABI
+
+Run:
+
+```bash
+./scripts/generate-abi.sh
+```
+
+This builds the contract (if needed) and writes the full Soroban contract
+spec to [`docs/abi.json`](./abi.json) via `stellar contract inspect`. The
+JSON includes every exported function with its parameter and return types,
+plus all `#[contracttype]` structs and enums used in the public interface.
+
+## Human-readable reference
+
+* **Function reference** — see `docs/abi.json` for the authoritative,
+  up-to-date list of all exported functions. Key entry points:
+  * SEP-40 interface: `base`, `decimals`, `resolution`, `assets`,
+    `lastprice`, `price`, `prices`
+  * Price submission: `submit_price`, `submit_prices`,
+    `submit_price_with_volume`, `submit_price_with_proof`
+  * Price queries: `get_price`, `get_price_with_confidence`,
+    `get_source_price`, `get_historical_price`
+  * Source/asset management: `add_source`, `remove_source`,
+    `register_asset`, `unregister_asset`
+* **Error codes** — see [`docs/error-codes.md`](./error-codes.md) for the
+  full error code registry (all `#[contracterror]` variants with
+  descriptions).
+
+## Keeping the ABI current
+
+The `abi-check` job in `.github/workflows/ci.yml` regenerates the ABI from
+the built WASM on every push/PR and publishes it as a build artifact, so
+consumers always have access to an ABI generated from the exact commit
+being tested. Run `./scripts/generate-abi.sh` locally to produce the same
+file for local integration work.

--- a/docs/event-schema-registry.md
+++ b/docs/event-schema-registry.md
@@ -1,0 +1,68 @@
+# Event Schema Registry
+
+The contract emits Soroban events (see `contracts/price-oracle/src/events.rs`)
+for every state-changing operation. This registry provides versioned,
+structured schemas for the core events consumers most commonly subscribe to,
+so off-chain indexers can validate and parse event payloads deterministically.
+
+Schemas live under [`schemas/events/v1/`](../schemas/events/v1/) as one
+JSON Schema file per event, named `<event_topic>.schema.json`. Avro
+equivalents (for Kafka/streaming consumers) live alongside them as
+`<event_topic>.avsc`.
+
+## Versioning
+
+* Schemas are versioned by directory (`schemas/events/v1/`, `v2/`, ...).
+* A new version directory is added only on a **breaking** change (field
+  removed, type changed, semantics changed). Additive, backward-compatible
+  fields are added to the current version.
+* Each event struct's Rust definition in `events.rs` is the source of
+  truth; schema changes must accompany the corresponding Rust change in the
+  same PR.
+
+## Core events (v1)
+
+| Topic | Rust struct | Schema |
+|---|---|---|
+| `price_submitted` | `PriceSubmittedEvent` | [schema](../schemas/events/v1/price_submitted.schema.json) |
+| `price_aggregated` | `PriceAggregatedEvent` | [schema](../schemas/events/v1/price_aggregated.schema.json) |
+| `source_added` | `SourceAddedEvent` | [schema](../schemas/events/v1/source_added.schema.json) |
+| `source_removed` | `SourceRemovedEvent` | [schema](../schemas/events/v1/source_removed.schema.json) |
+| `asset_registered` | `AssetRegisteredEvent` | [schema](../schemas/events/v1/asset_registered.schema.json) |
+| `circuit_breaker_tripped` | `CircuitBreakerTrippedEvent` | [schema](../schemas/events/v1/circuit_breaker_tripped.schema.json) |
+
+Other event types not yet listed here follow the same struct-to-schema
+convention; open a PR adding a `<topic>.schema.json` / `.avsc` pair under
+`schemas/events/v1/` and a row to the table above when you need one
+formalized.
+
+## Example consumer (JavaScript, JSON Schema validation)
+
+```js
+import Ajv from "ajv";
+import schema from "./schemas/events/v1/price_submitted.schema.json" assert { type: "json" };
+
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
+
+function handleEvent(rawEvent) {
+  if (!validate(rawEvent)) {
+    throw new Error(`Invalid price_submitted event: ${ajv.errorsText(validate.errors)}`);
+  }
+  // rawEvent is now known to match the v1 price_submitted schema
+}
+```
+
+## Example consumer (Python, Avro/streaming)
+
+```python
+from fastavro import schemaless_reader
+import io
+
+with open("schemas/events/v1/price_submitted.avsc") as f:
+    import json
+    schema = json.load(f)
+
+def decode(payload: bytes):
+    return schemaless_reader(io.BytesIO(payload), schema)
+```

--- a/docs/external-adapter.md
+++ b/docs/external-adapter.md
@@ -1,0 +1,67 @@
+# Chainlink-Style External Adapter Interface
+
+This lets operators running existing Chainlink External Adapter (EA)
+tooling submit prices to this oracle without changing their job specs,
+by fronting the contract with an adapter that speaks the standard
+Chainlink EA request/response format.
+
+## Specification
+
+**Endpoint:** `POST /submit`
+
+**Request body** (standard Chainlink EA job-run payload):
+
+```json
+{
+  "id": "job-run-id",
+  "data": {
+    "asset": "CA...ASSET_CONTRACT_ID",
+    "price": "100000000",
+    "timestamp": 1735000000
+  }
+}
+```
+
+* `data.asset` — Stellar contract/account address of the asset, as
+  registered via `register_asset`.
+* `data.price` — raw price scaled by `10^decimals`, as a decimal string
+  (fits Chainlink's `i128`-unsafe JSON number handling).
+* `data.timestamp` — Unix timestamp (seconds) of the observation.
+
+**Response body** (standard Chainlink EA success/error envelope):
+
+```json
+{
+  "jobRunID": "job-run-id",
+  "status": "success",
+  "data": { "result": "<submitted-price>", "txHash": "<stellar-tx-hash>" }
+}
+```
+
+On failure, `status` is `"errored"` and `data.error` describes the
+failure (invalid signature, contract revert, etc).
+
+## Verification middleware
+
+Requests must carry an `X-EA-Signature` header: `hex(HMAC-SHA256(body,
+ADAPTER_SHARED_SECRET))`. The adapter rejects any request whose
+signature doesn't match before touching the contract, so an operator's
+existing EA node only needs the shared secret configured, not a Stellar
+key on the request path itself. The adapter holds the Stellar submission
+key server-side (see `--source-identity` below).
+
+## Reference implementation
+
+See [`scripts/chainlink_adapter.py`](../scripts/chainlink_adapter.py) —
+a minimal stdlib-only HTTP server implementing the endpoint and
+signature middleware, then shelling out to `stellar contract invoke ...
+submit_price` for the actual on-chain submission.
+
+```bash
+export ADAPTER_SHARED_SECRET="..."
+python3 scripts/chainlink_adapter.py \
+  --contract CXXXX... \
+  --source-identity my-source-key \
+  --network testnet \
+  --port 8080
+```

--- a/schemas/events/v1/asset_registered.avsc
+++ b/schemas/events/v1/asset_registered.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "record",
+  "name": "AssetRegisteredEvent",
+  "namespace": "com.stellaroracle.events.v1",
+  "fields": [
+    { "name": "asset", "type": "string" },
+    { "name": "admin", "type": "string" }
+  ]
+}

--- a/schemas/events/v1/asset_registered.schema.json
+++ b/schemas/events/v1/asset_registered.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stellar-unified-price-oracle/schemas/events/v1/asset_registered.schema.json",
+  "title": "AssetRegisteredEvent",
+  "description": "Emitted when a new asset is registered for price tracking.",
+  "type": "object",
+  "properties": {
+    "asset": { "type": "string", "description": "Stellar address of the newly registered asset (topic)." },
+    "admin": { "type": "string", "description": "Stellar address of the admin who registered the asset (topic)." }
+  },
+  "required": ["asset", "admin"],
+  "additionalProperties": false
+}

--- a/schemas/events/v1/circuit_breaker_tripped.avsc
+++ b/schemas/events/v1/circuit_breaker_tripped.avsc
@@ -1,0 +1,14 @@
+{
+  "type": "record",
+  "name": "CircuitBreakerTrippedEvent",
+  "namespace": "com.stellaroracle.events.v1",
+  "fields": [
+    { "name": "asset", "type": "string" },
+    { "name": "previous_price", "type": "string" },
+    { "name": "candidate_price", "type": "string" },
+    { "name": "change_bps", "type": "int" },
+    { "name": "max_change_bps", "type": "int" },
+    { "name": "ledger", "type": "int" },
+    { "name": "timestamp", "type": "long" }
+  ]
+}

--- a/schemas/events/v1/circuit_breaker_tripped.schema.json
+++ b/schemas/events/v1/circuit_breaker_tripped.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stellar-unified-price-oracle/schemas/events/v1/circuit_breaker_tripped.schema.json",
+  "title": "CircuitBreakerTrippedEvent",
+  "description": "Emitted when an asset's circuit breaker trips and the update is rejected.",
+  "type": "object",
+  "properties": {
+    "asset": { "type": "string", "description": "Stellar address of the asset that triggered the breaker (topic)." },
+    "previous_price": { "type": "string", "description": "Previous aggregate price before the rejected update (i128 decimal string)." },
+    "candidate_price": { "type": "string", "description": "Candidate aggregate price that would have been published (i128 decimal string)." },
+    "change_bps": { "type": "integer", "minimum": 0, "description": "Change amount in basis points that exceeded the configured limit." },
+    "max_change_bps": { "type": "integer", "minimum": 0, "description": "Maximum allowed change in basis points for a single ledger." },
+    "ledger": { "type": "integer", "minimum": 0, "description": "Ledger at which the breaker tripped." },
+    "timestamp": { "type": "integer", "minimum": 0, "description": "Unix timestamp of the breaker trip." }
+  },
+  "required": ["asset", "previous_price", "candidate_price", "change_bps", "max_change_bps", "ledger", "timestamp"],
+  "additionalProperties": false
+}

--- a/schemas/events/v1/price_aggregated.avsc
+++ b/schemas/events/v1/price_aggregated.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "PriceAggregatedEvent",
+  "namespace": "com.stellaroracle.events.v1",
+  "fields": [
+    { "name": "asset", "type": "string" },
+    { "name": "price", "type": "string" },
+    { "name": "num_sources", "type": "int" },
+    { "name": "timestamp", "type": "long" }
+  ]
+}

--- a/schemas/events/v1/price_aggregated.schema.json
+++ b/schemas/events/v1/price_aggregated.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stellar-unified-price-oracle/schemas/events/v1/price_aggregated.schema.json",
+  "title": "PriceAggregatedEvent",
+  "description": "Emitted each time a successful price aggregation occurs for an asset.",
+  "type": "object",
+  "properties": {
+    "asset": { "type": "string", "description": "Stellar address of the asset (topic)." },
+    "price": { "type": "string", "description": "Newly computed aggregate price (i128 decimal string)." },
+    "num_sources": { "type": "integer", "minimum": 0, "description": "Number of sources that contributed to this aggregate." },
+    "timestamp": { "type": "integer", "minimum": 0, "description": "Unix timestamp of the most-recent contributing submission." }
+  },
+  "required": ["asset", "price", "num_sources", "timestamp"],
+  "additionalProperties": false
+}

--- a/schemas/events/v1/price_submitted.avsc
+++ b/schemas/events/v1/price_submitted.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "PriceSubmittedEvent",
+  "namespace": "com.stellaroracle.events.v1",
+  "fields": [
+    { "name": "asset", "type": "string" },
+    { "name": "source", "type": "string" },
+    { "name": "price", "type": "string", "doc": "i128 decimal string, scaled by 10^decimals" },
+    { "name": "timestamp", "type": "long" }
+  ]
+}

--- a/schemas/events/v1/price_submitted.schema.json
+++ b/schemas/events/v1/price_submitted.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stellar-unified-price-oracle/schemas/events/v1/price_submitted.schema.json",
+  "title": "PriceSubmittedEvent",
+  "description": "Emitted when a source submits a new price for an asset.",
+  "type": "object",
+  "properties": {
+    "asset": { "type": "string", "description": "Stellar contract/account address of the asset (topic)." },
+    "source": { "type": "string", "description": "Stellar address of the submitting oracle source (topic)." },
+    "price": { "type": "string", "description": "Raw price value scaled by 10^decimals, encoded as a decimal string (i128)." },
+    "timestamp": { "type": "integer", "minimum": 0, "description": "Unix timestamp (seconds) provided by the source." }
+  },
+  "required": ["asset", "source", "price", "timestamp"],
+  "additionalProperties": false
+}

--- a/schemas/events/v1/source_added.avsc
+++ b/schemas/events/v1/source_added.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "name": "SourceAddedEvent",
+  "namespace": "com.stellaroracle.events.v1",
+  "fields": [
+    { "name": "source", "type": "string" },
+    { "name": "admin", "type": "string" },
+    { "name": "name", "type": "string" }
+  ]
+}

--- a/schemas/events/v1/source_added.schema.json
+++ b/schemas/events/v1/source_added.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stellar-unified-price-oracle/schemas/events/v1/source_added.schema.json",
+  "title": "SourceAddedEvent",
+  "description": "Emitted when a new oracle source is registered by the admin.",
+  "type": "object",
+  "properties": {
+    "source": { "type": "string", "description": "Stellar address of the newly added oracle source (topic)." },
+    "admin": { "type": "string", "description": "Stellar address of the admin who performed the action (topic)." },
+    "name": { "type": "string", "description": "Human-readable display name assigned to the source." }
+  },
+  "required": ["source", "admin", "name"],
+  "additionalProperties": false
+}

--- a/schemas/events/v1/source_removed.avsc
+++ b/schemas/events/v1/source_removed.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "record",
+  "name": "SourceRemovedEvent",
+  "namespace": "com.stellaroracle.events.v1",
+  "fields": [
+    { "name": "source", "type": "string" },
+    { "name": "admin", "type": "string" }
+  ]
+}

--- a/schemas/events/v1/source_removed.schema.json
+++ b/schemas/events/v1/source_removed.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stellar-unified-price-oracle/schemas/events/v1/source_removed.schema.json",
+  "title": "SourceRemovedEvent",
+  "description": "Emitted when an oracle source is de-registered by the admin.",
+  "type": "object",
+  "properties": {
+    "source": { "type": "string", "description": "Stellar address of the removed oracle source (topic)." },
+    "admin": { "type": "string", "description": "Stellar address of the admin who performed the action (topic)." }
+  },
+  "required": ["source", "admin"],
+  "additionalProperties": false
+}

--- a/scripts/chainlink_adapter.py
+++ b/scripts/chainlink_adapter.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Chainlink-style external adapter reference implementation.
+
+Exposes POST /submit accepting a standard Chainlink EA job-run payload,
+verifies an HMAC-SHA256 request signature, and forwards the price to the
+oracle contract via `stellar contract invoke ... submit_price`.
+
+See docs/external-adapter.md for the request/response spec.
+"""
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+SHARED_SECRET = os.environ.get("ADAPTER_SHARED_SECRET", "")
+
+
+def verify_signature(body: bytes, signature: str) -> bool:
+    if not SHARED_SECRET or not signature:
+        return False
+    expected = hmac.new(SHARED_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+def submit_price(contract_id: str, source_identity: str, network: str,
+                  asset: str, price: str, timestamp: int) -> str:
+    result = subprocess.run(
+        [
+            "stellar", "contract", "invoke",
+            "--id", contract_id,
+            "--source", source_identity,
+            "--network", network,
+            "--", "submit_price",
+            "--source", source_identity,
+            "--asset", asset,
+            "--price", price,
+            "--timestamp", str(timestamp),
+        ],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def make_handler(contract_id: str, source_identity: str, network: str):
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            if self.path != "/submit":
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            signature = self.headers.get("X-EA-Signature", "")
+            job_id = None
+
+            try:
+                payload = json.loads(body)
+                job_id = payload.get("id")
+
+                if not verify_signature(body, signature):
+                    raise PermissionError("invalid or missing signature")
+
+                data = payload["data"]
+                tx_hash = submit_price(
+                    contract_id, source_identity, network,
+                    data["asset"], str(data["price"]), int(data["timestamp"]),
+                )
+                response = {
+                    "jobRunID": job_id,
+                    "status": "success",
+                    "data": {"result": str(data["price"]), "txHash": tx_hash},
+                }
+                status_code = 200
+            except Exception as exc:  # noqa: BLE001 - EA envelope reports all failures uniformly
+                response = {
+                    "jobRunID": job_id,
+                    "status": "errored",
+                    "data": {"error": str(exc)},
+                }
+                status_code = 400
+
+            body_out = json.dumps(response).encode()
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body_out)))
+            self.end_headers()
+            self.wfile.write(body_out)
+
+        def log_message(self, fmt, *args):
+            pass
+
+    return Handler
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", required=True, help="Oracle contract ID")
+    parser.add_argument("--source-identity", required=True, help="Stellar CLI identity used to sign submissions")
+    parser.add_argument("--network", default="testnet")
+    parser.add_argument("--port", type=int, default=8080)
+    args = parser.parse_args()
+
+    if not SHARED_SECRET:
+        raise SystemExit("ADAPTER_SHARED_SECRET environment variable must be set")
+
+    handler = make_handler(args.contract, args.source_identity, args.network)
+    server = HTTPServer(("0.0.0.0", args.port), handler)
+    print(f"Chainlink adapter listening on :{args.port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-abi.sh
+++ b/scripts/generate-abi.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# generate-abi.sh — Regenerate the machine-readable contract ABI from the
+# built WASM's on-chain spec (source of truth: contracts/price-oracle/src).
+#
+# Usage: ./scripts/generate-abi.sh
+#
+# Outputs:
+#   docs/abi.json — machine-readable Soroban contract spec (function
+#                   signatures, parameter types, struct/enum definitions)
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WASM_PATH="$ROOT_DIR/target/wasm32v1-none/release/price_oracle.wasm"
+OUT_PATH="$ROOT_DIR/docs/abi.json"
+
+if [[ ! -f "$WASM_PATH" ]]; then
+    echo "Building contract wasm..."
+    cargo build -p price-oracle --target wasm32v1-none --release --manifest-path "$ROOT_DIR/Cargo.toml"
+fi
+
+echo "Extracting ABI from $WASM_PATH ..."
+stellar contract inspect --wasm "$WASM_PATH" --output json > "$OUT_PATH"
+
+echo "ABI written to $OUT_PATH"

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -107,6 +107,20 @@ DESCRIPTION=$(invoke get_description)
 [[ -n "$DESCRIPTION" ]] && pass "description is set" || fail "description is empty"
 
 # ---------------------------------------------------------------------------
+# 3b. SEP-40 compliance (base, decimals, resolution, assets, lastprice, price, prices)
+# ---------------------------------------------------------------------------
+info "=== 3b. SEP-40 compliance ==="
+SEP40_FUNCS=(base decimals resolution assets lastprice price prices)
+CONTRACT_SPEC=$(stellar contract invoke --id "$CONTRACT_ID" --source "$ADMIN_IDENTITY" --network "$NETWORK" -- --help 2>&1 || true)
+for fn in "${SEP40_FUNCS[@]}"; do
+    if echo "$CONTRACT_SPEC" | grep -qE "(^|[[:space:]])${fn}([[:space:]]|$)"; then
+        pass "SEP-40 function '$fn' is present in contract interface"
+    else
+        fail "SEP-40 function '$fn' missing from contract interface"
+    fi
+done
+
+# ---------------------------------------------------------------------------
 # 4. Register test source and verify
 # ---------------------------------------------------------------------------
 info "=== 4. Register test source ==="


### PR DESCRIPTION
## Summary
- SEP-40 interface compliance check added to `scripts/verify-deployment.sh`
- Machine-readable ABI generation (`scripts/generate-abi.sh`, `docs/abi.md`) wired into CI as an `abi-check` job that builds the contract and publishes `docs/abi.json` as an artifact
- Versioned event schema registry (`schemas/events/v1/*.schema.json` + `*.avsc`) for core events, with docs and consumer examples at `docs/event-schema-registry.md`
- Chainlink-style external adapter spec, HMAC-signature verification middleware, and a reference implementation (`docs/external-adapter.md`, `scripts/chainlink_adapter.py`)

## Validation performed
- `bash -n` syntax check on modified/added shell scripts
- JSON/Avro schema files validated with `JSON.parse`
- Reviewed CI workflow YAML for correctness

Closes: #275
Closes: #277
Closes: #276
Closes: #286