### PR TITLE
Add guided deploy CLI, alert rules, price bot, and SDKs

### DIFF
--- a/docs/monitoring-setup.md
+++ b/docs/monitoring-setup.md
@@ -115,6 +115,10 @@ Full metrics reference: [`docs/monitoring/README.md`](./monitoring/README.md)
 
 ### Prometheus alerting rules (`alerts.yml`)
 
+The full, canonical rule set (including `OracleAllSourcesDown`, `OracleStalePriceData`,
+and `OraclePriceSpike`) lives in [`docs/monitoring/alerts.yml`](monitoring/alerts.yml) —
+point Prometheus's `rule_files:` at it directly. Excerpt:
+
 ```yaml
 groups:
   - name: oracle

--- a/docs/monitoring/alerts.yml
+++ b/docs/monitoring/alerts.yml
@@ -1,0 +1,67 @@
+# Prometheus alerting rules for the Stellar Unified Price Oracle.
+# Load into Prometheus via `rule_files:` and pair with the Grafana dashboard
+# at docs/monitoring/grafana-dashboard.json. Thresholds documented in
+# docs/monitoring-setup.md#3-alert-thresholds-and-severity-levels.
+groups:
+  - name: oracle
+    rules:
+      - alert: OracleSourceDown
+        expr: rate(oracle_price_submissions_total[15m]) == 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oracle source {{ $labels.source_name }} is not submitting"
+
+      - alert: OracleAllSourcesDown
+        expr: oracle_registered_sources_total == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No registered oracle sources — aggregation cannot proceed"
+
+      - alert: OracleInsufficientSources
+        expr: rate(oracle_errors_total{error_name="InsufficientSources"}[5m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Oracle aggregation failing — not enough active sources"
+
+      - alert: OracleStalePriceData
+        expr: time() - oracle_latest_price_timestamp > 600
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oracle price for {{ $labels.asset }} has not updated in over 600s"
+
+      - alert: OraclePriceSpike
+        expr: abs(oracle_price_delta_ratio) > 0.10
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oracle price for {{ $labels.asset }} moved more than 10% since last reading"
+
+      - alert: OracleUnauthorizedAttempt
+        expr: rate(oracle_errors_total{error_name="NotAuthorized"}[5m]) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Elevated rate of unauthorized calls against the oracle contract"
+
+      - alert: OracleAdminChanged
+        expr: increase(oracle_config_change_events_total{event_type="AdminChanged"}[1m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "Oracle admin address changed — verify this was intentional"
+
+      - alert: OracleContractUpgraded
+        expr: increase(oracle_config_change_events_total{event_type="ContractUpgraded"}[1m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "Oracle contract upgraded — verify wasm hash"

--- a/scripts/Dockerfile.bot
+++ b/scripts/Dockerfile.bot
@@ -1,0 +1,20 @@
+# Production image for price-submission-bot.py
+FROM python:3.11-slim
+
+ARG STELLAR_CLI_VERSION=22.0.0
+RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+    curl -sSfL "https://github.com/stellar/stellar-cli/releases/download/v${STELLAR_CLI_VERSION}/stellar-cli-${STELLAR_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+      | tar xz -C /usr/local/bin stellar && \
+    apt-get purge -y curl && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY price-submission-bot.py .
+COPY bot_config.example.toml ./bot_config.toml
+
+ENV BOT_CONFIG=/app/bot_config.toml
+EXPOSE 9100
+
+CMD ["python", "price-submission-bot.py"]

--- a/scripts/bot_config.example.toml
+++ b/scripts/bot_config.example.toml
@@ -1,0 +1,28 @@
+[oracle]
+contract_id = "CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+network     = "testnet"
+
+[source]
+name = "default"  # stellar CLI identity used to sign submissions
+
+[health]
+port = 9100
+
+[schedule]
+interval_secs = 60  # default submission interval, overridable per asset
+
+[assets.BTC]
+contract_address = "CBTC..."
+interval_secs     = 60
+[assets.BTC.feed_ids]
+coingecko = "bitcoin"
+binance   = "BTCUSDT"
+kraken    = "XBTUSD"
+
+[assets.ETH]
+contract_address = "CETH..."
+interval_secs     = 60
+[assets.ETH.feed_ids]
+coingecko = "ethereum"
+binance   = "ETHUSDT"
+kraken    = "ETHUSD"

--- a/scripts/deploy-oracle.sh
+++ b/scripts/deploy-oracle.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# deploy-oracle.sh — Interactive guided deployment CLI for the Price Oracle contract.
+#
+# Walks an operator through network selection, admin setup, initialization
+# parameters, source/asset registration, and a test submission, then runs
+# post-deployment verification and writes a deployment report.
+#
+# Usage: ./scripts/deploy-oracle.sh [--wasm <path/to/price_oracle.wasm>]
+#
+# Prerequisites: stellar CLI (https://developers.stellar.org/docs/tools/developer-tools)
+
+set -euo pipefail
+
+WASM_PATH="target/wasm32v1-none/release/price_oracle.wasm"
+REPORT_FILE="deployment-report-$(date +%Y%m%d-%H%M%S).md"
+
+info()  { echo -e "\033[1;33m==>\033[0m $*"; }
+die()   { echo "ERROR: $*" >&2; exit 1; }
+ask()   { local prompt="$1" def="${2:-}" reply; read -r -p "$prompt${def:+ [$def]}: " reply; echo "${reply:-$def}"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --wasm) WASM_PATH="$2"; shift 2 ;;
+    *) die "Unknown argument: $1" ;;
+  esac
+done
+
+command -v stellar >/dev/null 2>&1 || die "stellar CLI not found on PATH"
+[[ -f "$WASM_PATH" ]] || die "WASM not found at $WASM_PATH (build with 'npm run build:contract' first)"
+
+info "Stellar Unified Price Oracle — Guided Deployment"
+
+# ── 1. Network selection ─────────────────────────────────────────────────
+echo "Select network:"
+select NETWORK in testnet futurenet mainnet standalone; do
+  [[ -n "$NETWORK" ]] && break
+done
+
+# ── 2. Admin setup ───────────────────────────────────────────────────────
+ADMIN_IDENTITY=$(ask "Admin identity (stellar CLI identity name)" "default")
+stellar keys address "$ADMIN_IDENTITY" >/dev/null 2>&1 || die "Identity '$ADMIN_IDENTITY' not found — run 'stellar keys generate $ADMIN_IDENTITY' first"
+ADMIN_ADDRESS=$(stellar keys address "$ADMIN_IDENTITY")
+info "Admin address: $ADMIN_ADDRESS"
+
+# ── 3. Initialization parameters ─────────────────────────────────────────
+MIN_SOURCES=$(ask "min_sources_required" "3")
+MAX_HISTORY=$(ask "max_history_length" "100")
+DECIMALS=$(ask "decimals" "14")
+RESOLUTION=$(ask "resolution" "300")
+
+# ── 4. Deploy ─────────────────────────────────────────────────────────────
+info "Deploying contract to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_PATH" \
+  --source "$ADMIN_IDENTITY" \
+  --network "$NETWORK")
+info "Deployed: $CONTRACT_ID"
+
+info "Initializing..."
+stellar contract invoke --id "$CONTRACT_ID" --source "$ADMIN_IDENTITY" --network "$NETWORK" \
+  -- initialize --admin "$ADMIN_ADDRESS" \
+  --min_sources_required "$MIN_SOURCES" --max_history_length "$MAX_HISTORY" \
+  --decimals "$DECIMALS" --resolution "$RESOLUTION"
+
+# ── 5. Source registration ───────────────────────────────────────────────
+REGISTER_SOURCE=$(ask "Register an initial price source now? (y/n)" "n")
+SOURCE_ADDRESS=""
+if [[ "$REGISTER_SOURCE" == "y" ]]; then
+  SOURCE_ADDRESS=$(ask "Source address")
+  SOURCE_NAME=$(ask "Source name" "primary")
+  stellar contract invoke --id "$CONTRACT_ID" --source "$ADMIN_IDENTITY" --network "$NETWORK" \
+    -- add_source --source "$SOURCE_ADDRESS" --name "$SOURCE_NAME"
+  info "Source registered: $SOURCE_ADDRESS"
+fi
+
+# ── 6. Asset registration ────────────────────────────────────────────────
+REGISTER_ASSET=$(ask "Register an initial asset now? (y/n)" "n")
+ASSET_ADDRESS=""
+if [[ "$REGISTER_ASSET" == "y" ]]; then
+  ASSET_ADDRESS=$(ask "Asset contract address")
+  stellar contract invoke --id "$CONTRACT_ID" --source "$ADMIN_IDENTITY" --network "$NETWORK" \
+    -- register_asset --asset "$ASSET_ADDRESS"
+  info "Asset registered: $ASSET_ADDRESS"
+fi
+
+# ── 7. Test submission ───────────────────────────────────────────────────
+TEST_SUBMIT="skipped"
+if [[ -n "$SOURCE_ADDRESS" && -n "$ASSET_ADDRESS" ]]; then
+  DO_TEST=$(ask "Submit a test price now? (y/n)" "n")
+  if [[ "$DO_TEST" == "y" ]]; then
+    TEST_PRICE=$(ask "Test price (integer, scaled by decimals)" "100000000000000")
+    NOW=$(date +%s)
+    stellar contract invoke --id "$CONTRACT_ID" --source "$ADMIN_IDENTITY" --network "$NETWORK" \
+      -- submit_price --source "$SOURCE_ADDRESS" --asset "$ASSET_ADDRESS" \
+      --price "$TEST_PRICE" --timestamp "$NOW"
+    TEST_SUBMIT="ok (price=$TEST_PRICE @ $NOW)"
+    info "Test submission successful."
+  fi
+fi
+
+# ── 8. Post-deployment verification ──────────────────────────────────────
+info "Running post-deployment verification..."
+VERIFY_OUTPUT="(skipped — verify-deployment.sh not found)"
+if [[ -x "$(dirname "$0")/verify-deployment.sh" ]]; then
+  VERIFY_OUTPUT=$("$(dirname "$0")/verify-deployment.sh" \
+    --contract "$CONTRACT_ID" --admin "$ADMIN_IDENTITY" --network "$NETWORK" 2>&1) || true
+  echo "$VERIFY_OUTPUT"
+fi
+
+# ── 9. Deployment report ─────────────────────────────────────────────────
+cat > "$REPORT_FILE" <<EOF
+# Deployment Report
+
+- **Date:** $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+- **Network:** $NETWORK
+- **Contract ID:** $CONTRACT_ID
+- **Admin:** $ADMIN_ADDRESS ($ADMIN_IDENTITY)
+- **min_sources_required:** $MIN_SOURCES
+- **max_history_length:** $MAX_HISTORY
+- **decimals:** $DECIMALS
+- **resolution:** $RESOLUTION
+- **Initial source:** ${SOURCE_ADDRESS:-none}
+- **Initial asset:** ${ASSET_ADDRESS:-none}
+- **Test submission:** $TEST_SUBMIT
+
+## Verification Output
+\`\`\`
+$VERIFY_OUTPUT
+\`\`\`
+EOF
+
+info "Deployment report written to $REPORT_FILE"
+info "Done."

--- a/scripts/price-submission-bot.py
+++ b/scripts/price-submission-bot.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Production price submission bot for the Stellar Unified Price Oracle.
+
+Fetches prices for configured assets from multiple exchanges (CoinGecko,
+Binance, Kraken), aggregates a mid-price, and submits to the oracle
+contract on a per-asset schedule with retry/backoff. Exposes a Prometheus
+health/metrics endpoint. Configuration follows docs/price-submission-bot.md.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+import tomllib
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from typing import Optional
+
+import requests
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("oracle-bot")
+
+METRICS = {
+    "submissions_total": 0,
+    "submission_errors_total": 0,
+    "fetch_errors_total": {"coingecko": 0, "binance": 0, "kraken": 0},
+    "last_submission_ts": {},
+}
+
+FETCHERS = {
+    "coingecko": lambda feed_id: requests.get(
+        "https://api.coingecko.com/api/v3/simple/price",
+        params={"ids": feed_id, "vs_currencies": "usd"}, timeout=10,
+    ).json()[feed_id]["usd"],
+    "binance": lambda feed_id: float(requests.get(
+        "https://api.binance.com/api/v3/ticker/price",
+        params={"symbol": feed_id}, timeout=10,
+    ).json()["price"]),
+    "kraken": lambda feed_id: float(next(iter(requests.get(
+        "https://api.kraken.com/0/public/Ticker",
+        params={"pair": feed_id}, timeout=10,
+    ).json()["result"].values()))["c"][0]),
+}
+
+
+@dataclass
+class AssetConfig:
+    contract_address: str
+    feed_ids: dict = field(default_factory=dict)  # exchange -> feed id
+    interval_secs: int = 60
+
+
+def load_config(path: str) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def fetch_mid_price(asset: AssetConfig) -> Optional[float]:
+    prices = []
+    for exchange, feed_id in asset.feed_ids.items():
+        fetcher = FETCHERS.get(exchange)
+        if not fetcher:
+            continue
+        try:
+            prices.append(fetcher(feed_id))
+        except Exception as exc:  # network/parse errors from a single source shouldn't halt the cycle
+            METRICS["fetch_errors_total"][exchange] += 1
+            log.warning("fetch failed for %s/%s: %s", exchange, feed_id, exc)
+    if not prices:
+        return None
+    return sum(prices) / len(prices)
+
+
+def submit_price(contract_id: str, network: str, source_identity: str, asset_address: str,
+                  price: int, timestamp: int, retries: int = 3) -> bool:
+    for attempt in range(1, retries + 1):
+        try:
+            subprocess.run(
+                [
+                    "stellar", "contract", "invoke",
+                    "--id", contract_id, "--source", source_identity, "--network", network,
+                    "--", "submit_price",
+                    "--source", source_identity, "--asset", asset_address,
+                    "--price", str(price), "--timestamp", str(timestamp),
+                ],
+                check=True, capture_output=True, timeout=30,
+            )
+            return True
+        except Exception as exc:
+            backoff = 2 ** attempt
+            log.warning("submit attempt %d/%d failed: %s (retrying in %ds)", attempt, retries, exc, backoff)
+            time.sleep(backoff)
+    return False
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path == "/metrics":
+            lines = [
+                f"oracle_bot_submissions_total {METRICS['submissions_total']}",
+                f"oracle_bot_submission_errors_total {METRICS['submission_errors_total']}",
+            ]
+            for exchange, count in METRICS["fetch_errors_total"].items():
+                lines.append(f'oracle_bot_fetch_errors_total{{exchange="{exchange}"}} {count}')
+            body = "\n".join(lines) + "\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(body.encode())
+        elif self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "ok", "metrics": METRICS}).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, fmt, *args):  # silence default request logging
+        pass
+
+
+def run_health_server(port: int) -> None:
+    HTTPServer(("0.0.0.0", port), HealthHandler).serve_forever()
+
+
+def run_asset_loop(contract_id: str, network: str, source_identity: str,
+                    asset_name: str, cfg: AssetConfig) -> None:
+    while True:
+        price = fetch_mid_price(cfg)
+        if price is not None:
+            scaled = int(price * 10**14)
+            ok = submit_price(contract_id, network, source_identity, cfg.contract_address,
+                               scaled, int(time.time()))
+            if ok:
+                METRICS["submissions_total"] += 1
+                METRICS["last_submission_ts"][asset_name] = int(time.time())
+                log.info("submitted %s = %s", asset_name, price)
+            else:
+                METRICS["submission_errors_total"] += 1
+                log.error("submission failed for %s after retries", asset_name)
+        else:
+            log.error("no price data available for %s", asset_name)
+        time.sleep(cfg.interval_secs)
+
+
+def main() -> None:
+    config_path = os.environ.get("BOT_CONFIG", "bot_config.toml")
+    config = load_config(config_path)
+
+    oracle = config["oracle"]
+    source_identity = config["source"]["name"]
+    health_port = int(config.get("health", {}).get("port", 9100))
+
+    Thread(target=run_health_server, args=(health_port,), daemon=True).start()
+    log.info("health/metrics endpoint listening on :%d", health_port)
+
+    threads = []
+    for asset_name, asset_cfg in config["assets"].items():
+        cfg = AssetConfig(
+            contract_address=asset_cfg["contract_address"],
+            feed_ids=asset_cfg["feed_ids"],
+            interval_secs=asset_cfg.get("interval_secs", config.get("schedule", {}).get("interval_secs", 60)),
+        )
+        t = Thread(target=run_asset_loop, args=(oracle["contract_id"], oracle["network"],
+                                                  source_identity, asset_name, cfg), daemon=True)
+        t.start()
+        threads.append(t)
+
+    for t in threads:
+        t.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,48 @@
+# Stellar Unified Price Oracle — SDKs
+
+Type-safe client libraries for interacting with the oracle contract, covering price
+queries, price submission, subscription management, and source/asset registry lookups.
+Both SDKs share the same auth model (a Stellar `Keypair`/identity signs write calls;
+reads are simulated and unsigned) and JSON-friendly serialization of contract types.
+
+The core surface below is intentionally the high-traffic subset of the contract's
+endpoints; the contract itself exposes many more admin/governance functions (see
+`contracts/price-oracle/src/lib.rs`) that can be wrapped the same way as needed.
+
+## TypeScript
+
+```ts
+import { OracleClient } from "@stellar-oracle/sdk";
+import { Keypair } from "@stellar/stellar-sdk";
+
+const client = new OracleClient({
+  contractId: "CXXXX...",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+});
+
+const price = await client.getPrice("CBTC...", 600n);
+
+const signer = Keypair.fromSecret(process.env.SOURCE_SECRET_KEY!);
+await client.submitPrice("CSOURCE...", "CBTC...", 6500000000000000n, BigInt(Math.floor(Date.now() / 1000)), signer);
+```
+
+Build: `cd sdk/typescript && npm install && npm run build`
+
+## Python
+
+```python
+from oracle_sdk import OracleClient, OracleClientConfig
+from stellar_sdk import Keypair
+
+client = OracleClient(OracleClientConfig(
+    contract_id="CXXXX...",
+    rpc_url="https://soroban-testnet.stellar.org",
+))
+
+price = client.get_price("CBTC...", max_age=600)
+
+signer = Keypair.from_secret(os.environ["SOURCE_SECRET_KEY"])
+client.submit_price("CSOURCE...", "CBTC...", price=6500000000000000, timestamp=int(time.time()), signer=signer)
+```
+
+Install: `cd sdk/python && pip install -e .`

--- a/sdk/python/oracle_sdk/__init__.py
+++ b/sdk/python/oracle_sdk/__init__.py
@@ -1,0 +1,3 @@
+from .client import OracleClient, PriceEntry
+
+__all__ = ["OracleClient", "PriceEntry"]

--- a/sdk/python/oracle_sdk/client.py
+++ b/sdk/python/oracle_sdk/client.py
@@ -1,0 +1,103 @@
+"""Type-hinted Python SDK for the Stellar Unified Price Oracle contract."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from stellar_sdk import Account, Keypair, Network, SorobanServer, TransactionBuilder, scval
+from stellar_sdk.soroban_rpc import GetTransactionStatus
+
+
+@dataclass
+class PriceEntry:
+    price: int
+    timestamp: int
+
+
+@dataclass
+class OracleClientConfig:
+    contract_id: str
+    rpc_url: str
+    network_passphrase: str = Network.TESTNET_NETWORK_PASSPHRASE
+
+
+class OracleClient:
+    """Auth-aware, typed client for the oracle contract's core endpoints."""
+
+    def __init__(self, config: OracleClientConfig) -> None:
+        self.config = config
+        self.server = SorobanServer(config.rpc_url)
+
+    def _invoke(self, method: str, args: list, signer: Keypair):
+        source = self.server.load_account(signer.public_key)
+        tx = (
+            TransactionBuilder(source, self.config.network_passphrase, base_fee=100_000)
+            .add_time_bounds(0, 0)
+            .append_invoke_contract_function_op(self.config.contract_id, method, args)
+            .build()
+        )
+        prepared = self.server.prepare_transaction(tx)
+        prepared.sign(signer)
+        send_result = self.server.send_transaction(prepared)
+
+        status = send_result.status
+        for _ in range(10):
+            if status != "PENDING":
+                break
+            time.sleep(1)
+            result = self.server.get_transaction(send_result.hash)
+            status = result.status
+            if status == GetTransactionStatus.SUCCESS:
+                return result.return_value
+        if status != GetTransactionStatus.SUCCESS:
+            raise RuntimeError(f"transaction {send_result.hash} failed with status {status}")
+
+    def _view(self, method: str, args: list):
+        # Simulation doesn't require a funded/valid account; sequence number is unused.
+        source = Account(Keypair.random().public_key, 0)
+        tx = (
+            TransactionBuilder(source, self.config.network_passphrase, base_fee=100)
+            .add_time_bounds(0, 0)
+            .append_invoke_contract_function_op(self.config.contract_id, method, args)
+            .build()
+        )
+        sim = self.server.simulate_transaction(tx)
+        if sim.error:
+            raise RuntimeError(sim.error)
+        return sim.results[0].xdr if sim.results else None
+
+    # ── Price queries ────────────────────────────────────────────────
+    def get_price(self, asset: str, max_age: int) -> Optional[PriceEntry]:
+        return self._view("get_price", [scval.to_address(asset), scval.to_uint64(max_age)])
+
+    def get_source_price(self, asset: str, source: str) -> PriceEntry:
+        return self._view("get_source_price", [scval.to_address(asset), scval.to_address(source)])
+
+    def get_all_prices(self, asset: str) -> list[PriceEntry]:
+        return self._view("get_all_prices", [scval.to_address(asset)])
+
+    # ── Submission ──────────────────────────────────────────────────
+    def submit_price(self, source: str, asset: str, price: int, timestamp: int, signer: Keypair):
+        return self._invoke(
+            "submit_price",
+            [scval.to_address(source), scval.to_address(asset), scval.to_int128(price), scval.to_uint64(timestamp)],
+            signer,
+        )
+
+    # ── Subscription management ────────────────────────────────────
+    def subscribe(self, consumer: str, duration: int, signer: Keypair):
+        return self._invoke("subscribe", [scval.to_address(consumer), scval.to_uint32(duration)], signer)
+
+    def renew_subscription(self, consumer: str, signer: Keypair):
+        return self._invoke("renew_subscription", [scval.to_address(consumer)], signer)
+
+    def get_subscription_expiry(self, consumer: str) -> int:
+        return self._view("get_subscription_expiry", [scval.to_address(consumer)])
+
+    # ── Source / asset registry ────────────────────────────────────
+    def is_source(self, source: str) -> bool:
+        return self._view("is_source", [scval.to_address(source)])
+
+    def is_asset_registered(self, asset: str) -> bool:
+        return self._view("is_asset_registered", [scval.to_address(asset)])

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "stellar-oracle-sdk"
+version = "0.1.0"
+description = "Python SDK for the Stellar Unified Price Oracle contract"
+requires-python = ">=3.9"
+dependencies = ["stellar-sdk>=11.0.0"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@stellar-oracle/sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the Stellar Unified Price Oracle contract",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "peerDependencies": {
+    "@stellar/stellar-sdk": "^12.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,110 @@
+import { Contract, SorobanRpc, TransactionBuilder, Networks, Keypair, Address, Account, nativeToScVal, scValToNative } from "@stellar/stellar-sdk";
+
+/** Sequence number is irrelevant for a simulated (unsubmitted) transaction. */
+const SIMULATION_SOURCE = new Account(Keypair.random().publicKey(), "0");
+
+export interface OracleClientConfig {
+  contractId: string;
+  rpcUrl: string;
+  networkPassphrase?: string;
+}
+
+export interface PriceEntry {
+  price: bigint;
+  timestamp: bigint;
+}
+
+/** Type-safe client for the Stellar Unified Price Oracle contract. */
+export class OracleClient {
+  private readonly server: SorobanRpc.Server;
+  private readonly contract: Contract;
+  private readonly networkPassphrase: string;
+
+  constructor(private readonly config: OracleClientConfig) {
+    this.server = new SorobanRpc.Server(config.rpcUrl);
+    this.contract = new Contract(config.contractId);
+    this.networkPassphrase = config.networkPassphrase ?? Networks.TESTNET;
+  }
+
+  /** Sign and submit a transaction invoking `method` with `args`, using `signer` for auth. */
+  private async invoke(method: string, args: unknown[], signer: Keypair) {
+    const account = await this.server.getAccount(signer.publicKey());
+    const scArgs = args.map((a) => nativeToScVal(a, {}));
+    const tx = new TransactionBuilder(account, {
+      fee: "100000",
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(this.contract.call(method, ...scArgs))
+      .setTimeout(30)
+      .build();
+
+    const prepared = await this.server.prepareTransaction(tx);
+    prepared.sign(signer);
+    const sendResult = await this.server.sendTransaction(prepared);
+
+    let status = sendResult.status;
+    let hash = sendResult.hash;
+    for (let i = 0; i < 10 && status === "PENDING"; i++) {
+      await new Promise((r) => setTimeout(r, 1000));
+      const res = await this.server.getTransaction(hash);
+      status = res.status as typeof status;
+      if (status === "SUCCESS") return res.returnValue ? scValToNative(res.returnValue) : undefined;
+    }
+    if (status !== "SUCCESS") throw new Error(`Transaction ${hash} failed with status ${status}`);
+  }
+
+  /** Read-only simulation call — no signature or fee required. */
+  private async view(method: string, args: unknown[]) {
+    const scArgs = args.map((a) => nativeToScVal(a, {}));
+    const tx = new TransactionBuilder(SIMULATION_SOURCE, {
+      fee: "100",
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(this.contract.call(method, ...scArgs))
+      .setTimeout(30)
+      .build();
+    const sim = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(sim)) throw new Error(sim.error);
+    return sim.result?.retval ? scValToNative(sim.result.retval) : undefined;
+  }
+
+  // ── Price queries ────────────────────────────────────────────────────
+  async getPrice(asset: string, maxAge: bigint): Promise<PriceEntry | null> {
+    return this.view("get_price", [Address.fromString(asset), maxAge]);
+  }
+
+  async getSourcePrice(asset: string, source: string): Promise<PriceEntry> {
+    return this.view("get_source_price", [Address.fromString(asset), Address.fromString(source)]);
+  }
+
+  async getAllPrices(asset: string): Promise<PriceEntry[]> {
+    return this.view("get_all_prices", [Address.fromString(asset)]);
+  }
+
+  // ── Submission ───────────────────────────────────────────────────────
+  async submitPrice(source: string, asset: string, price: bigint, timestamp: bigint, signer: Keypair) {
+    return this.invoke("submit_price", [Address.fromString(source), Address.fromString(asset), price, timestamp], signer);
+  }
+
+  // ── Subscription management ─────────────────────────────────────────
+  async subscribe(consumer: string, duration: number, signer: Keypair) {
+    return this.invoke("subscribe", [Address.fromString(consumer), duration], signer);
+  }
+
+  async renewSubscription(consumer: string, signer: Keypair) {
+    return this.invoke("renew_subscription", [Address.fromString(consumer)], signer);
+  }
+
+  async getSubscriptionExpiry(consumer: string): Promise<bigint> {
+    return this.view("get_subscription_expiry", [Address.fromString(consumer)]);
+  }
+
+  // ── Source / asset registry ─────────────────────────────────────────
+  async isSource(source: string): Promise<boolean> {
+    return this.view("is_source", [Address.fromString(source)]);
+  }
+
+  async isAssetRegistered(asset: string): Promise<boolean> {
+    return this.view("is_asset_registered", [Address.fromString(asset)]);
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,2 @@
+export { OracleClient } from "./client";
+export type { OracleClientConfig, PriceEntry } from "./client";

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- `scripts/deploy-oracle.sh`: interactive guided deployment CLI — network selection, admin setup, init params, source/asset registration, test submission, post-deployment verification (reuses `verify-deployment.sh`), and a generated deployment report.
- `docs/monitoring/alerts.yml`: standalone Prometheus alerting rules (8 alerts covering source health, insufficient sources, stale/spiking prices, unauthorized access, and admin/upgrade changes) for the existing Grafana dashboard (`docs/monitoring/grafana-dashboard.json`), referenced from `docs/monitoring-setup.md`.
- `scripts/price-submission-bot.py` + `Dockerfile.bot` + `bot_config.example.toml`: production price submission bot — multi-exchange fetch (CoinGecko, Binance, Kraken), per-asset configurable schedule, retry with exponential backoff, and a Prometheus `/metrics` + `/health` endpoint.
- `sdk/`: TypeScript and Python SDKs with a typed client covering auth (Keypair-signed writes vs. simulated reads), serialization, price queries, submission, and subscription management, with a README and usage examples for both languages.

## Notes
- Pre-existing, unrelated bug found on `main`: `contracts/price-oracle/src/events.rs` has a missing `}` (~line 1557) that merges `AutoTriggerFiredEvent` into `PriceFrozenEvent`, breaking `cargo build`/`fmt`/`clippy` for the whole crate. This blocks the repo's pre-commit/pre-push hooks for any change right now, not just this PR. Bypassed hooks for this push only (confirmed with repo owner) since fixing it is outside the scope of these issues — recommend filing a separate issue to fix `events.rs`.

## Validation performed
- Shell syntax check (`bash -n`) on `deploy-oracle.sh`
- Python syntax check (`ast.parse`) on `price-submission-bot.py` and the Python SDK client
- YAML/TOML/JSON parse checks on `alerts.yml`, `bot_config.example.toml`, and the TS SDK's `package.json`/`tsconfig.json`
- Verified CLI flag names in `deploy-oracle.sh` match `verify-deployment.sh`
- Full `cargo build`/`fmt`/`clippy` could not be run due to the pre-existing unrelated compile error above

Closes #271
Closes #272
Closes #273
Closes #274