### PR TITLE
Feature/cross chain bridges registry adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ See [`docs/error-codes.md`](docs/error-codes.md) for the full registry with caus
 ## Documentation
 
 - [Price Submission Bot Design](docs/price-submission-bot.md) — off-chain bot architecture for automated price submissions
+- [Signed CEX/Aggregator Adapters](docs/signed-price-adapters.md) — CoinGecko/Binance/Coinbase adapters with failover, staleness handling, and signed submission (#216)
 - [Disaster Recovery Plan](docs/disaster-recovery.md) — failure scenario playbooks and recovery procedures
 - [Architecture](docs/ARCHITECTURE.md) — contract design and data flow
 - [Monitoring](docs/monitoring/README.md) — Grafana dashboard and alerting setup

--- a/contracts/price-oracle/src/asset_registry.rs
+++ b/contracts/price-oracle/src/asset_registry.rs
@@ -1,0 +1,354 @@
+//! # Canonical Cross-Chain Asset Registry
+//!
+//! A single source of truth mapping a Stellar asset address to its
+//! representation(s) on foreign chains (contract/token address, decimals).
+//! Cross-chain modules — Axelar GMP ([`crate::axelar_gmp`]), LayerZero
+//! ([`crate::layerzero`]), and manual cross-reference checks
+//! ([`crate::cross_chain_verify`]) — resolve foreign asset identifiers
+//! through this registry instead of maintaining their own ad-hoc mappings.
+//!
+//! ## Schema
+//!
+//! A mapping is keyed by `(chain, foreign_address)`:
+//! * `chain` — a short canonical chain identifier (e.g. `"ethereum"`,
+//!   `"polygon"`). Bridge integrations that identify chains differently
+//!   (LayerZero's numeric `src_eid`, for example) translate their own
+//!   identifier onto this canonical namespace rather than inventing a
+//!   parallel one — see [`crate::layerzero::set_lz_chain_name`].
+//! * `foreign_address` — the 32-byte canonical representation of the
+//!   asset's contract/token address on that chain (left-padded for
+//!   shorter addresses such as 20-byte EVM addresses).
+//!
+//! Each mapping also carries the foreign asset's `decimals` so callers can
+//! rescale a price without a second lookup, and an `enabled` flag so admins
+//! can suspend a mapping without losing its history.
+
+use soroban_sdk::{panic_with_error, Address, BytesN, Env, String, Vec};
+
+use crate::events::{
+    ForeignAssetMappedEvent, ForeignAssetMappingRemovedEvent, ForeignAssetMappingUpdatedEvent,
+};
+use crate::storage::{check_registered_asset, get_admin, LEDGER_BUMP, LEDGER_THRESHOLD};
+use crate::types::{DataKey, ErrorCode, ForeignAssetMapping};
+
+fn mapping_key(chain: &String, foreign_address: &BytesN<32>) -> DataKey {
+    DataKey::ForeignAssetMapping(chain.clone(), foreign_address.clone())
+}
+
+fn append_index(env: &Env, key: DataKey, entry: (String, BytesN<32>)) {
+    let mut list: Vec<(String, BytesN<32>)> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+    list.push_back(entry);
+    env.storage().persistent().set(&key, &list);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+}
+
+fn remove_from_index(env: &Env, key: DataKey, entry: &(String, BytesN<32>)) {
+    let list: Vec<(String, BytesN<32>)> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+    let mut updated: Vec<(String, BytesN<32>)> = Vec::new(env);
+    for item in list.iter() {
+        if item != *entry {
+            updated.push_back(item);
+        }
+    }
+    env.storage().persistent().set(&key, &updated);
+}
+
+/// Registers a new canonical mapping from `stellar_asset` to its representation
+/// on `chain`. Admin-only.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+/// * [`ErrorCode::AssetNotRegistered`] — `stellar_asset` is not a registered asset.
+/// * [`ErrorCode::ForeignAssetAlreadyMapped`] — a mapping already exists for
+///   `(chain, foreign_address)`.
+pub fn register_foreign_asset_mapping(
+    env: &Env,
+    stellar_asset: Address,
+    chain: String,
+    foreign_address: BytesN<32>,
+    decimals: u32,
+) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    check_registered_asset(env, &stellar_asset);
+
+    let key = mapping_key(&chain, &foreign_address);
+    if env.storage().persistent().has(&key) {
+        panic_with_error!(env, ErrorCode::ForeignAssetAlreadyMapped);
+    }
+
+    let mapping = ForeignAssetMapping {
+        stellar_asset: stellar_asset.clone(),
+        chain: chain.clone(),
+        foreign_address: foreign_address.clone(),
+        decimals,
+        enabled: true,
+    };
+    env.storage().persistent().set(&key, &mapping);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+    append_index(
+        env,
+        DataKey::ForeignAssetRegistryList,
+        (chain.clone(), foreign_address.clone()),
+    );
+    append_index(
+        env,
+        DataKey::AssetForeignMappings(stellar_asset.clone()),
+        (chain.clone(), foreign_address.clone()),
+    );
+
+    ForeignAssetMappedEvent {
+        stellar_asset,
+        chain,
+        foreign_address,
+        decimals,
+    }
+    .publish(env);
+}
+
+/// Updates an existing mapping's `decimals` and `enabled` flag. Admin-only.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+/// * [`ErrorCode::ForeignAssetNotMapped`] — no mapping exists for `(chain, foreign_address)`.
+pub fn update_foreign_asset_mapping(
+    env: &Env,
+    chain: String,
+    foreign_address: BytesN<32>,
+    decimals: u32,
+    enabled: bool,
+) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    let key = mapping_key(&chain, &foreign_address);
+    let mut mapping: ForeignAssetMapping = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ForeignAssetNotMapped));
+
+    mapping.decimals = decimals;
+    mapping.enabled = enabled;
+    env.storage().persistent().set(&key, &mapping);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+    ForeignAssetMappingUpdatedEvent {
+        stellar_asset: mapping.stellar_asset,
+        chain,
+        foreign_address,
+        decimals,
+        enabled,
+    }
+    .publish(env);
+}
+
+/// Permanently removes a foreign asset mapping. Admin-only.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+/// * [`ErrorCode::ForeignAssetNotMapped`] — no mapping exists for `(chain, foreign_address)`.
+pub fn remove_foreign_asset_mapping(env: &Env, chain: String, foreign_address: BytesN<32>) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    let key = mapping_key(&chain, &foreign_address);
+    let mapping: ForeignAssetMapping = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ForeignAssetNotMapped));
+
+    env.storage().persistent().remove(&key);
+
+    let entry = (chain.clone(), foreign_address.clone());
+    remove_from_index(env, DataKey::ForeignAssetRegistryList, &entry);
+    remove_from_index(
+        env,
+        DataKey::AssetForeignMappings(mapping.stellar_asset.clone()),
+        &entry,
+    );
+
+    ForeignAssetMappingRemovedEvent {
+        stellar_asset: mapping.stellar_asset,
+        chain,
+        foreign_address,
+    }
+    .publish(env);
+}
+
+/// Returns the mapping for `(chain, foreign_address)`, if any — regardless of
+/// its `enabled` state.
+pub fn get_foreign_asset_mapping(
+    env: &Env,
+    chain: String,
+    foreign_address: BytesN<32>,
+) -> Option<ForeignAssetMapping> {
+    env.storage().persistent().get(&mapping_key(&chain, &foreign_address))
+}
+
+/// Returns every foreign-chain mapping currently registered for `asset`.
+pub fn get_foreign_mappings_for_asset(env: &Env, asset: Address) -> Vec<ForeignAssetMapping> {
+    let keys: Vec<(String, BytesN<32>)> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::AssetForeignMappings(asset))
+        .unwrap_or(Vec::new(env));
+
+    let mut result = Vec::new(env);
+    for (chain, foreign_address) in keys.iter() {
+        if let Some(mapping) = get_foreign_asset_mapping(env, chain, foreign_address) {
+            result.push_back(mapping);
+        }
+    }
+    result
+}
+
+/// Resolves an *enabled* mapping for `(chain, foreign_address)`, panicking if
+/// the asset has no mapping or the mapping has been disabled.
+///
+/// Used internally by bridge integrations ([`crate::axelar_gmp`],
+/// [`crate::layerzero`]) to turn a wire-format foreign asset id into the
+/// Stellar asset it should update.
+///
+/// # Errors
+///
+/// * [`ErrorCode::ForeignAssetNotMapped`] — no mapping exists.
+/// * [`ErrorCode::ForeignAssetMappingDisabled`] — the mapping exists but is disabled.
+pub(crate) fn resolve_enabled_mapping(
+    env: &Env,
+    chain: &String,
+    foreign_address: &BytesN<32>,
+) -> ForeignAssetMapping {
+    let mapping: ForeignAssetMapping = env
+        .storage()
+        .persistent()
+        .get(&mapping_key(chain, foreign_address))
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ForeignAssetNotMapped));
+
+    if !mapping.enabled {
+        panic_with_error!(env, ErrorCode::ForeignAssetMappingDisabled);
+    }
+    mapping
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Env;
+
+    fn setup(env: &Env) -> (Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let asset = Address::generate(env);
+        crate::admin::initialize(
+            env,
+            admin.clone(),
+            1,
+            100,
+            18,
+            String::from_str(env, "Oracle"),
+        );
+        crate::assets::register_asset(env, asset.clone());
+        (admin, asset)
+    }
+
+    #[test]
+    fn test_register_and_resolve_mapping() {
+        let env = Env::default();
+        let (_, asset) = setup(&env);
+
+        let chain = String::from_str(&env, "ethereum");
+        let foreign_address = BytesN::from_array(&env, &[7u8; 32]);
+
+        register_foreign_asset_mapping(&env, asset.clone(), chain.clone(), foreign_address.clone(), 6);
+
+        let mapping = resolve_enabled_mapping(&env, &chain, &foreign_address);
+        assert_eq!(mapping.stellar_asset, asset);
+        assert_eq!(mapping.decimals, 6);
+        assert!(mapping.enabled);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_duplicate_mapping_rejected() {
+        let env = Env::default();
+        let (_, asset) = setup(&env);
+
+        let chain = String::from_str(&env, "ethereum");
+        let foreign_address = BytesN::from_array(&env, &[1u8; 32]);
+        register_foreign_asset_mapping(&env, asset.clone(), chain.clone(), foreign_address.clone(), 6);
+        register_foreign_asset_mapping(&env, asset, chain, foreign_address, 6);
+    }
+
+    #[test]
+    fn test_disable_mapping_updates_flag() {
+        let env = Env::default();
+        let (_, asset) = setup(&env);
+
+        let chain = String::from_str(&env, "polygon");
+        let foreign_address = BytesN::from_array(&env, &[2u8; 32]);
+        register_foreign_asset_mapping(&env, asset, chain.clone(), foreign_address.clone(), 18);
+
+        update_foreign_asset_mapping(&env, chain.clone(), foreign_address.clone(), 18, false);
+
+        let mapping = get_foreign_asset_mapping(&env, chain, foreign_address).unwrap();
+        assert!(!mapping.enabled);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_disabled_mapping_rejected_by_bridges() {
+        let env = Env::default();
+        let (_, asset) = setup(&env);
+
+        let chain = String::from_str(&env, "polygon");
+        let foreign_address = BytesN::from_array(&env, &[2u8; 32]);
+        register_foreign_asset_mapping(&env, asset, chain.clone(), foreign_address.clone(), 18);
+        update_foreign_asset_mapping(&env, chain.clone(), foreign_address.clone(), 18, false);
+
+        resolve_enabled_mapping(&env, &chain, &foreign_address);
+    }
+
+    #[test]
+    fn test_remove_mapping() {
+        let env = Env::default();
+        let (_, asset) = setup(&env);
+
+        let chain = String::from_str(&env, "avalanche");
+        let foreign_address = BytesN::from_array(&env, &[3u8; 32]);
+        register_foreign_asset_mapping(&env, asset.clone(), chain.clone(), foreign_address.clone(), 18);
+        assert!(get_foreign_asset_mapping(&env, chain.clone(), foreign_address.clone()).is_some());
+
+        remove_foreign_asset_mapping(&env, chain.clone(), foreign_address.clone());
+        assert!(get_foreign_asset_mapping(&env, chain, foreign_address).is_none());
+
+        let remaining = get_foreign_mappings_for_asset(&env, asset);
+        assert_eq!(remaining.len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_chains_for_one_asset() {
+        let env = Env::default();
+        let (_, asset) = setup(&env);
+
+        let eth = String::from_str(&env, "ethereum");
+        let poly = String::from_str(&env, "polygon");
+        register_foreign_asset_mapping(&env, asset.clone(), eth, BytesN::from_array(&env, &[4u8; 32]), 6);
+        register_foreign_asset_mapping(&env, asset.clone(), poly, BytesN::from_array(&env, &[5u8; 32]), 18);
+
+        let mappings = get_foreign_mappings_for_asset(&env, asset);
+        assert_eq!(mappings.len(), 2);
+    }
+}

--- a/contracts/price-oracle/src/axelar_gmp.rs
+++ b/contracts/price-oracle/src/axelar_gmp.rs
@@ -1,0 +1,340 @@
+//! # Axelar GMP Integration
+//!
+//! Lets a foreign-chain price attestation reach this oracle over Axelar's
+//! General Message Passing (GMP), as an alternative to the in-house relay
+//! (`cross_chain_relay`, #182) that leans on Axelar's own validator network
+//! for trust minimization instead of a bespoke light client.
+//!
+//! ## Trust model
+//!
+//! Axelar's Gateway contract is the trust root: its verifier set
+//! independently confirms that a source-chain contract genuinely sent a
+//! given message before ever calling into a destination contract. Mirroring
+//! the "AxelarExecutable" pattern used on EVM chains (`execute()` only
+//! trusts `msg.sender == gateway`), this module only accepts calls whose
+//! `gateway` argument matches the admin-configured trusted Gateway address
+//! *and* authorizes the call (`gateway.require_auth()`) — which a direct
+//! contract-to-contract invocation from the real Axelar Gateway satisfies
+//! automatically. All GMP signature/quorum verification is Axelar's
+//! responsibility and happens inside the Gateway contract, not here.
+//!
+//! ## Message format
+//!
+//! The GMP `payload` bytes are the canonical
+//! [`crate::types::CrossChainPricePayload`] wire format defined in
+//! [`crate::bridge_common`] — shared with the LayerZero integration so a
+//! single format is used regardless of transport. The payload's
+//! `foreign_asset` id is resolved to a Stellar asset via the canonical
+//! [`crate::asset_registry`], keyed by `source_chain`.
+//!
+//! ## Replay protection
+//!
+//! Each GMP message carries a unique Axelar-assigned `command_id`. This
+//! module records every `command_id` it has executed and rejects repeats.
+//!
+//! ## Relayer / keeper
+//!
+//! Once the Gateway has approved a command, delivering it here is
+//! permissionless — any keeper may relay the call, exactly as with a real
+//! `AxelarExecutable`, since authorization comes from the Gateway's own
+//! approval rather than from the caller's identity.
+
+use soroban_sdk::{panic_with_error, Address, Bytes, BytesN, Env, String};
+
+use crate::asset_registry::resolve_enabled_mapping;
+use crate::bridge_common::{apply_bridged_price, decode_price_payload};
+use crate::events::{AxelarGatewaySetEvent, AxelarMessageExecutedEvent, AxelarTrustedSourceSetEvent};
+use crate::pause::check_not_paused;
+use crate::storage::{check_source, get_admin, LEDGER_BUMP, LEDGER_THRESHOLD};
+use crate::types::{DataKey, ErrorCode};
+
+/// Configures the trusted Axelar Gateway contract address. Admin-only.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+pub fn set_axelar_gateway(env: &Env, gateway: Address) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::AxelarGateway, &gateway);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::AxelarGateway, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+    AxelarGatewaySetEvent { gateway }.publish(env);
+}
+
+/// Returns the currently configured Axelar Gateway address, if any.
+pub fn get_axelar_gateway(env: &Env) -> Option<Address> {
+    env.storage().persistent().get(&DataKey::AxelarGateway)
+}
+
+/// Registers `bridge_source` — an already-registered oracle source (see
+/// [`crate::sources::add_source`]) — as the attribution target for GMP
+/// messages arriving from `(source_chain, source_address)`. Admin-only.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+/// * [`ErrorCode::NotAuthorized`] (via [`check_source`]) — `bridge_source` is
+///   not a registered oracle source.
+pub fn set_axelar_trusted_source(
+    env: &Env,
+    source_chain: String,
+    source_address: String,
+    bridge_source: Address,
+) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    check_source(env, &bridge_source);
+
+    let key = DataKey::AxelarTrustedSource(source_chain.clone(), source_address.clone());
+    env.storage().persistent().set(&key, &bridge_source);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+    AxelarTrustedSourceSetEvent {
+        bridge_source,
+        source_chain,
+        source_address,
+    }
+    .publish(env);
+}
+
+/// Revokes a trusted Axelar GMP source. Admin-only.
+pub fn remove_axelar_trusted_source(env: &Env, source_chain: String, source_address: String) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .remove(&DataKey::AxelarTrustedSource(source_chain, source_address));
+}
+
+fn read_trusted_source(env: &Env, source_chain: &String, source_address: &String) -> Address {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AxelarTrustedSource(
+            source_chain.clone(),
+            source_address.clone(),
+        ))
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::AxelarSourceNotTrusted))
+}
+
+/// Delivers a price update relayed over Axelar GMP.
+///
+/// `gateway` must equal the configured trusted Gateway address and must
+/// authorize this call — satisfied automatically when the real Axelar
+/// Gateway contract invokes this function directly after its own
+/// verifier-set quorum check has approved the message.
+///
+/// # Errors
+///
+/// * [`ErrorCode::AxelarGatewayNotConfigured`] — no Gateway has been configured.
+/// * [`ErrorCode::NotAuthorized`] — `gateway` does not match the configured Gateway.
+/// * [`ErrorCode::AxelarCommandAlreadyExecuted`] — `command_id` was already processed.
+/// * [`ErrorCode::AxelarSourceNotTrusted`] — no bridge source is registered for
+///   `(source_chain, source_address)`.
+/// * [`ErrorCode::ForeignAssetNotMapped`] / [`ErrorCode::ForeignAssetMappingDisabled`] —
+///   the payload's foreign asset id has no active registry mapping on `source_chain`.
+pub fn execute_axelar_message(
+    env: &Env,
+    gateway: Address,
+    command_id: BytesN<32>,
+    source_chain: String,
+    source_address: String,
+    payload: Bytes,
+) {
+    check_not_paused(env);
+
+    let configured = get_axelar_gateway(env)
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::AxelarGatewayNotConfigured));
+    if gateway != configured {
+        panic_with_error!(env, ErrorCode::NotAuthorized);
+    }
+    gateway.require_auth();
+
+    let executed_key = DataKey::AxelarExecutedCommand(command_id.clone());
+    if env.storage().persistent().has(&executed_key) {
+        panic_with_error!(env, ErrorCode::AxelarCommandAlreadyExecuted);
+    }
+    env.storage().persistent().set(&executed_key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&executed_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+    let bridge_source = read_trusted_source(env, &source_chain, &source_address);
+    let message = decode_price_payload(env, &payload);
+    let mapping = resolve_enabled_mapping(env, &source_chain, &message.foreign_asset);
+
+    apply_bridged_price(
+        env,
+        bridge_source.clone(),
+        mapping.stellar_asset.clone(),
+        message.price,
+        message.timestamp,
+        message.decimals,
+        source_chain.clone(),
+    );
+
+    AxelarMessageExecutedEvent {
+        asset: mapping.stellar_asset,
+        bridge_source,
+        command_id,
+        source_chain,
+        source_address,
+        price: message.price,
+    }
+    .publish(env);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge_common::encode_price_payload;
+    use crate::types::CrossChainPricePayload;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+
+    fn setup(env: &Env) -> (Address, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let asset = Address::generate(env);
+        crate::admin::initialize(env, admin.clone(), 1, 100, 18, String::from_str(env, "Oracle"));
+        crate::assets::register_asset(env, asset.clone());
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+        (admin, asset, Address::generate(env))
+    }
+
+    fn wire_axelar(
+        env: &Env,
+        asset: &Address,
+        gateway: &Address,
+        bridge_source: &Address,
+        chain: &String,
+        foreign_address: &BytesN<32>,
+    ) {
+        crate::sources::add_source(env, bridge_source.clone(), String::from_str(env, "Axelar"));
+        crate::sources::add_source_asset(env, bridge_source.clone(), asset.clone());
+        set_axelar_gateway(env, gateway.clone());
+        set_axelar_trusted_source(
+            env,
+            chain.clone(),
+            String::from_str(env, "0xSourceContract"),
+            bridge_source.clone(),
+        );
+        crate::asset_registry::register_foreign_asset_mapping(
+            env,
+            asset.clone(),
+            chain.clone(),
+            foreign_address.clone(),
+            18,
+        );
+    }
+
+    #[test]
+    fn test_execute_axelar_message_updates_price() {
+        let env = Env::default();
+        let (_, asset, gateway) = setup(&env);
+        let bridge_source = Address::generate(&env);
+        let chain = String::from_str(&env, "ethereum");
+        let foreign_address = BytesN::from_array(&env, &[11u8; 32]);
+        wire_axelar(&env, &asset, &gateway, &bridge_source, &chain, &foreign_address);
+
+        let payload = CrossChainPricePayload {
+            foreign_asset: foreign_address,
+            price: 1_000_000_000_000_000_000i128,
+            decimals: 18,
+            timestamp: env.ledger().timestamp(),
+            nonce: 1,
+        };
+        let encoded = encode_price_payload(&env, &payload);
+
+        execute_axelar_message(
+            &env,
+            gateway,
+            BytesN::from_array(&env, &[1u8; 32]),
+            chain,
+            String::from_str(&env, "0xSourceContract"),
+            encoded,
+        );
+
+        let entry: crate::types::PriceEntry = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Submission(asset, bridge_source))
+            .unwrap();
+        assert_eq!(entry.price, 1_000_000_000_000_000_000i128);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_execute_axelar_message_rejects_replay() {
+        let env = Env::default();
+        let (_, asset, gateway) = setup(&env);
+        let bridge_source = Address::generate(&env);
+        let chain = String::from_str(&env, "ethereum");
+        let foreign_address = BytesN::from_array(&env, &[12u8; 32]);
+        wire_axelar(&env, &asset, &gateway, &bridge_source, &chain, &foreign_address);
+
+        let payload = CrossChainPricePayload {
+            foreign_asset: foreign_address,
+            price: 1_000_000_000_000_000_000i128,
+            decimals: 18,
+            timestamp: env.ledger().timestamp(),
+            nonce: 1,
+        };
+        let encoded = encode_price_payload(&env, &payload);
+        let command_id = BytesN::from_array(&env, &[2u8; 32]);
+
+        execute_axelar_message(
+            &env,
+            gateway.clone(),
+            command_id.clone(),
+            chain.clone(),
+            String::from_str(&env, "0xSourceContract"),
+            encoded.clone(),
+        );
+        // Second delivery of the same command_id must be rejected.
+        execute_axelar_message(
+            &env,
+            gateway,
+            command_id,
+            chain,
+            String::from_str(&env, "0xSourceContract"),
+            encoded,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_execute_axelar_message_rejects_untrusted_gateway() {
+        let env = Env::default();
+        let (_, asset, gateway) = setup(&env);
+        let bridge_source = Address::generate(&env);
+        let chain = String::from_str(&env, "ethereum");
+        let foreign_address = BytesN::from_array(&env, &[13u8; 32]);
+        wire_axelar(&env, &asset, &gateway, &bridge_source, &chain, &foreign_address);
+
+        let payload = CrossChainPricePayload {
+            foreign_asset: foreign_address,
+            price: 1_000_000_000_000_000_000i128,
+            decimals: 18,
+            timestamp: env.ledger().timestamp(),
+            nonce: 1,
+        };
+        let encoded = encode_price_payload(&env, &payload);
+
+        let impostor_gateway = Address::generate(&env);
+        execute_axelar_message(
+            &env,
+            impostor_gateway,
+            BytesN::from_array(&env, &[3u8; 32]),
+            chain,
+            String::from_str(&env, "0xSourceContract"),
+            encoded,
+        );
+    }
+}

--- a/contracts/price-oracle/src/bridge_common.rs
+++ b/contracts/price-oracle/src/bridge_common.rs
@@ -1,0 +1,194 @@
+//! # Shared Cross-Chain Bridge Plumbing
+//!
+//! Code shared by every bridge integration ([`crate::axelar_gmp`],
+//! [`crate::layerzero`]):
+//!
+//! * A single wire format ([`crate::types::CrossChainPricePayload`]) for the
+//!   price-update message carried over any transport.
+//! * A single "apply this bridged price" path that mirrors the pre-signed
+//!   submission flow in [`crate::signed_submission`] (min-price / staleness /
+//!   circuit-breaker checks, aggregation trigger) and additionally records
+//!   the observation into the existing cross-chain reference-price
+//!   verification store ([`crate::cross_chain_verify`]) so it can be
+//!   compared against locally aggregated prices from other sources.
+
+use soroban_sdk::{panic_with_error, Address, Bytes, BytesN, Env, String};
+
+use crate::admin::{get_decimals, get_timestamp_threshold};
+use crate::assets::get_min_price;
+use crate::pause::check_not_paused;
+use crate::prices::{check_deviation_circuit_breaker, do_aggregate, record_successful_submission};
+use crate::sources::{is_source_suspended, record_invalid_submission};
+use crate::storage::{
+    check_registered_asset, check_source, check_source_asset, LEDGER_BUMP, LEDGER_THRESHOLD,
+};
+use crate::types::{CrossChainPricePayload, DataKey, ErrorCode, PriceEntry};
+
+/// Wire length of the canonical [`CrossChainPricePayload`] encoding:
+/// `foreign_asset(32) || price_le(16) || decimals_le(4) || timestamp_le(8) || nonce_le(8)`.
+pub const PRICE_PAYLOAD_LEN: u32 = 32 + 16 + 4 + 8 + 8;
+
+fn read_array<const N: usize>(bytes: &Bytes, offset: u32) -> [u8; N] {
+    let mut arr = [0u8; N];
+    for i in 0..N {
+        arr[i] = bytes.get_unchecked(offset + i as u32);
+    }
+    arr
+}
+
+/// Encodes a [`CrossChainPricePayload`] into its canonical wire format.
+pub fn encode_price_payload(env: &Env, payload: &CrossChainPricePayload) -> Bytes {
+    let mut buf = Bytes::new(env);
+    buf.append(&payload.foreign_asset.clone().into());
+    buf.append(&Bytes::from_slice(env, &(payload.price as u128).to_le_bytes()));
+    buf.append(&Bytes::from_slice(env, &payload.decimals.to_le_bytes()));
+    buf.append(&Bytes::from_slice(env, &payload.timestamp.to_le_bytes()));
+    buf.append(&Bytes::from_slice(env, &payload.nonce.to_le_bytes()));
+    buf
+}
+
+/// Decodes the canonical wire format into a [`CrossChainPricePayload`].
+///
+/// # Errors
+///
+/// * [`ErrorCode::InvalidProof`] — `bytes` is not exactly [`PRICE_PAYLOAD_LEN`] long.
+pub fn decode_price_payload(env: &Env, bytes: &Bytes) -> CrossChainPricePayload {
+    if bytes.len() != PRICE_PAYLOAD_LEN {
+        panic_with_error!(env, ErrorCode::InvalidProof);
+    }
+
+    let foreign_asset: [u8; 32] = read_array(bytes, 0);
+    let price_bytes: [u8; 16] = read_array(bytes, 32);
+    let decimals_bytes: [u8; 4] = read_array(bytes, 48);
+    let timestamp_bytes: [u8; 8] = read_array(bytes, 52);
+    let nonce_bytes: [u8; 8] = read_array(bytes, 60);
+
+    CrossChainPricePayload {
+        foreign_asset: BytesN::from_array(env, &foreign_asset),
+        price: u128::from_le_bytes(price_bytes) as i128,
+        decimals: u32::from_le_bytes(decimals_bytes),
+        timestamp: u64::from_le_bytes(timestamp_bytes),
+        nonce: u64::from_le_bytes(nonce_bytes),
+    }
+}
+
+/// Applies a price update that has already been authenticated by a bridge
+/// integration, treating `bridge_source` (a registered oracle source
+/// dedicated to that bridge pathway) as the submitter.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — `bridge_source` is not a registered source,
+///   is not authorized for `asset`, or has been suspended.
+/// * [`ErrorCode::AssetNotRegistered`] — `asset` is not registered.
+/// * [`ErrorCode::InvalidPrice`] — `price` is `<= 0`.
+/// * [`ErrorCode::PriceBelowMinimum`] — `price` is below the asset's minimum price floor.
+/// * [`ErrorCode::InvalidTimestamp`] — `timestamp` is too far in the future.
+pub(crate) fn apply_bridged_price(
+    env: &Env,
+    bridge_source: Address,
+    asset: Address,
+    price: i128,
+    timestamp: u64,
+    payload_decimals: u32,
+    chain_id: String,
+) {
+    check_not_paused(env);
+    check_source(env, &bridge_source);
+    check_registered_asset(env, &asset);
+    check_source_asset(env, &bridge_source, &asset);
+
+    if is_source_suspended(env, bridge_source.clone()) {
+        panic_with_error!(env, ErrorCode::NotAuthorized);
+    }
+
+    if price <= 0 {
+        record_invalid_submission(env, bridge_source.clone());
+        panic_with_error!(env, ErrorCode::InvalidPrice);
+    }
+
+    let min_price = get_min_price(env, asset.clone());
+    if price < min_price {
+        panic_with_error!(env, ErrorCode::PriceBelowMinimum);
+    }
+
+    let ledger_time = env.ledger().timestamp();
+    let threshold = get_timestamp_threshold(env);
+    if timestamp > ledger_time.saturating_add(threshold) {
+        record_invalid_submission(env, bridge_source.clone());
+        panic_with_error!(env, ErrorCode::InvalidTimestamp);
+    }
+
+    if check_deviation_circuit_breaker(env, &bridge_source, &asset, price) {
+        return;
+    }
+
+    // Bridge into the existing cross-chain reference-price verification store
+    // (#226) so `verify_cross_chain_price` can compare this bridged
+    // observation against the price aggregated from other sources.
+    crate::cross_chain_verify::record_reference_price(
+        env,
+        asset.clone(),
+        bridge_source.clone(),
+        price,
+        payload_decimals,
+        chain_id,
+        timestamp,
+    );
+
+    let decimals = get_decimals(env);
+    let current_ledger = env.ledger().sequence();
+    let entry = PriceEntry {
+        price,
+        timestamp,
+        source: bridge_source.clone(),
+        decimals,
+        last_updated: current_ledger,
+        ledger_timestamp: ledger_time,
+        volume: None,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::Submission(asset.clone(), bridge_source.clone()), &entry);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Submission(asset.clone(), bridge_source.clone()),
+        LEDGER_THRESHOLD,
+        LEDGER_BUMP,
+    );
+
+    record_successful_submission(env, bridge_source);
+    crate::triggers::record_submission_for_triggers(env, &asset, price);
+
+    do_aggregate(env, &asset);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_decode_round_trip() {
+        let env = Env::default();
+        let payload = CrossChainPricePayload {
+            foreign_asset: BytesN::from_array(&env, &[9u8; 32]),
+            price: 123_456_789_000_000_000i128,
+            decimals: 18,
+            timestamp: 1_700_000_000,
+            nonce: 42,
+        };
+
+        let encoded = encode_price_payload(&env, &payload);
+        assert_eq!(encoded.len(), PRICE_PAYLOAD_LEN);
+
+        let decoded = decode_price_payload(&env, &encoded);
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_decode_rejects_wrong_length() {
+        let env = Env::default();
+        let bad = Bytes::from_slice(&env, &[0u8; 10]);
+        decode_price_payload(&env, &bad);
+    }
+}

--- a/contracts/price-oracle/src/cross_chain_verify.rs
+++ b/contracts/price-oracle/src/cross_chain_verify.rs
@@ -70,6 +70,23 @@ pub fn submit_cross_chain_price(
     let admin = get_admin(env);
     admin.require_auth();
 
+    record_reference_price(env, asset, oracle_chain, price, decimals, chain_id, timestamp);
+}
+
+/// Records a cross-chain reference price observation without an authorization
+/// check, so it can be shared by [`submit_cross_chain_price`] (admin-submitted)
+/// and the bridge integrations in [`crate::bridge_common`] (Axelar GMP,
+/// LayerZero), which authenticate the observation through their own trust
+/// model before calling this.
+pub(crate) fn record_reference_price(
+    env: &Env,
+    asset: Address,
+    oracle_chain: Address,
+    price: i128,
+    decimals: u32,
+    chain_id: String,
+    timestamp: u64,
+) {
     crate::storage::check_registered_asset(env, &asset);
 
     if price <= 0 {
@@ -89,7 +106,7 @@ pub fn submit_cross_chain_price(
         &entry,
     );
 
-    env.storage().persistent().bump(
+    env.storage().persistent().extend_ttl(
         &DataKey::CrossChainPrice(asset, oracle_chain),
         LEDGER_THRESHOLD,
         LEDGER_BUMP,
@@ -168,7 +185,7 @@ mod tests {
     #[test]
     fn test_cross_chain_verification_flag() {
         let env = Env::default();
-        let admin = Address::random(&env);
+        let admin = Address::generate(&env);
 
         env.ledger().with_mut(|l| {
             l.timestamp = 1000;
@@ -180,7 +197,7 @@ mod tests {
             1,
             100,
             18,
-            SorobanString::from_slice(&env, "Oracle"),
+            SorobanString::from_str(&env, "Oracle"),
         );
 
         // Initially disabled
@@ -198,7 +215,7 @@ mod tests {
     #[test]
     fn test_price_within_threshold() {
         let env = Env::default();
-        let admin = Address::random(&env);
+        let admin = Address::generate(&env);
 
         env.ledger().with_mut(|l| {
             l.timestamp = 1000;
@@ -210,7 +227,7 @@ mod tests {
             1,
             100,
             18,
-            SorobanString::from_slice(&env, "Oracle"),
+            SorobanString::from_str(&env, "Oracle"),
         );
 
         set_cross_chain_verification_enabled(&env, true);
@@ -222,7 +239,7 @@ mod tests {
         let cross_chain = CrossChainPriceEntry {
             price: 101_500_000_000_000_000i128, // 101.5 * 10^16 (1.5% deviation)
             decimals: 18,
-            chain_id: SorobanString::from_slice(&env, "ethereum"),
+            chain_id: SorobanString::from_str(&env, "ethereum"),
             ledger: 1,
             timestamp: 1000,
         };
@@ -233,7 +250,7 @@ mod tests {
     #[test]
     fn test_price_exceeds_threshold() {
         let env = Env::default();
-        let admin = Address::random(&env);
+        let admin = Address::generate(&env);
 
         env.ledger().with_mut(|l| {
             l.timestamp = 1000;
@@ -245,7 +262,7 @@ mod tests {
             1,
             100,
             18,
-            SorobanString::from_slice(&env, "Oracle"),
+            SorobanString::from_str(&env, "Oracle"),
         );
 
         set_cross_chain_verification_enabled(&env, true);
@@ -257,7 +274,7 @@ mod tests {
         let cross_chain = CrossChainPriceEntry {
             price: 106_000_000_000_000_000i128, // 106 * 10^16 (6% deviation)
             decimals: 18,
-            chain_id: SorobanString::from_slice(&env, "ethereum"),
+            chain_id: SorobanString::from_str(&env, "ethereum"),
             ledger: 1,
             timestamp: 1000,
         };
@@ -268,7 +285,7 @@ mod tests {
     #[test]
     fn test_verification_disabled() {
         let env = Env::default();
-        let admin = Address::random(&env);
+        let admin = Address::generate(&env);
 
         env.ledger().with_mut(|l| {
             l.timestamp = 1000;
@@ -280,7 +297,7 @@ mod tests {
             1,
             100,
             18,
-            SorobanString::from_slice(&env, "Oracle"),
+            SorobanString::from_str(&env, "Oracle"),
         );
 
         // Verification disabled by default
@@ -291,7 +308,7 @@ mod tests {
         let cross_chain = CrossChainPriceEntry {
             price: 150_000_000_000_000_000i128, // 50% deviation - should pass because verification disabled
             decimals: 18,
-            chain_id: SorobanString::from_slice(&env, "ethereum"),
+            chain_id: SorobanString::from_str(&env, "ethereum"),
             ledger: 1,
             timestamp: 1000,
         };

--- a/contracts/price-oracle/src/errors.rs
+++ b/contracts/price-oracle/src/errors.rs
@@ -22,6 +22,7 @@ use soroban_sdk::contracterror;
 /// | 99–102 | Freeze/pagination/notify (#223,#229,#243) |
 /// | 103–107 | Relayer batch/bond/fee market (#264,#265,#266) |
 /// | 116–118 | Cross-chain asset registry |
+/// | 119–121 | Axelar GMP integration |
 #[contracterror]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ErrorCode {
@@ -251,4 +252,12 @@ pub enum ErrorCode {
     ForeignAssetNotMapped = 117,
     /// The foreign asset mapping exists but has been disabled by the admin.
     ForeignAssetMappingDisabled = 118,
+
+    // ── 119–121: Axelar GMP integration ────────────────────────────────────────
+    /// The Axelar Gateway contract address has not been configured.
+    AxelarGatewayNotConfigured = 119,
+    /// This Axelar `command_id` has already been executed (replay).
+    AxelarCommandAlreadyExecuted = 120,
+    /// No trusted bridge source is registered for this (source_chain, source_address).
+    AxelarSourceNotTrusted = 121,
 }

--- a/contracts/price-oracle/src/errors.rs
+++ b/contracts/price-oracle/src/errors.rs
@@ -21,6 +21,7 @@ use soroban_sdk::contracterror;
 /// | 99–101 | Signed submission (#216) |
 /// | 99–102 | Freeze/pagination/notify (#223,#229,#243) |
 /// | 103–107 | Relayer batch/bond/fee market (#264,#265,#266) |
+/// | 116–118 | Cross-chain asset registry |
 #[contracterror]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ErrorCode {
@@ -242,4 +243,12 @@ pub enum ErrorCode {
     TooManyCallbacks = 114,
     /// No callback registration found for the given (consumer, asset) pair (#297).
     CallbackNotFound = 115,
+
+    // ── 116–118: Canonical cross-chain asset registry ─────────────────────────
+    /// A foreign asset mapping already exists for this (chain, foreign_address) pair.
+    ForeignAssetAlreadyMapped = 116,
+    /// No foreign asset mapping exists for this (chain, foreign_address) pair.
+    ForeignAssetNotMapped = 117,
+    /// The foreign asset mapping exists but has been disabled by the admin.
+    ForeignAssetMappingDisabled = 118,
 }

--- a/contracts/price-oracle/src/errors.rs
+++ b/contracts/price-oracle/src/errors.rs
@@ -23,6 +23,7 @@ use soroban_sdk::contracterror;
 /// | 103–107 | Relayer batch/bond/fee market (#264,#265,#266) |
 /// | 116–118 | Cross-chain asset registry |
 /// | 119–121 | Axelar GMP integration |
+/// | 122–125 | LayerZero integration |
 #[contracterror]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ErrorCode {
@@ -260,4 +261,14 @@ pub enum ErrorCode {
     AxelarCommandAlreadyExecuted = 120,
     /// No trusted bridge source is registered for this (source_chain, source_address).
     AxelarSourceNotTrusted = 121,
+
+    // ── 122–125: LayerZero integration ─────────────────────────────────────────
+    /// The LayerZero Endpoint contract address has not been configured.
+    LzEndpointNotConfigured = 122,
+    /// The delivered nonce does not match the expected next nonce for this pathway.
+    LzNonceOutOfOrder = 123,
+    /// No trusted bridge source is registered for this (src_eid, sender) pathway.
+    LzRemoteNotTrusted = 124,
+    /// No canonical registry chain name is configured for this LayerZero src_eid.
+    LzChainNameNotConfigured = 125,
 }

--- a/contracts/price-oracle/src/events.rs
+++ b/contracts/price-oracle/src/events.rs
@@ -1839,3 +1839,40 @@ pub struct AxelarMessageExecutedEvent {
     pub source_address: String,
     pub price: i128,
 }
+
+// =============================================================================
+// LayerZero Integration Events
+// =============================================================================
+
+/// Emitted when the trusted LayerZero Endpoint address is (re)configured.
+#[contractevent]
+#[derive(Clone)]
+pub struct LzEndpointSetEvent {
+    #[topic]
+    pub endpoint: Address,
+}
+
+/// Emitted when a trusted LayerZero remote pathway is registered.
+#[contractevent]
+#[derive(Clone)]
+pub struct LzTrustedRemoteSetEvent {
+    #[topic]
+    pub bridge_source: Address,
+    pub src_eid: u32,
+    pub sender: BytesN<32>,
+}
+
+/// Emitted when a price is applied from a verified LayerZero message.
+#[contractevent]
+#[derive(Clone)]
+pub struct LzMessageReceivedEvent {
+    #[topic]
+    pub asset: Address,
+    #[topic]
+    pub bridge_source: Address,
+    pub src_eid: u32,
+    pub sender: BytesN<32>,
+    pub nonce: u64,
+    pub guid: BytesN<32>,
+    pub price: i128,
+}

--- a/contracts/price-oracle/src/events.rs
+++ b/contracts/price-oracle/src/events.rs
@@ -1765,3 +1765,41 @@ pub struct FeedMetadataUpdatedEvent {
     pub symbol: String,
     pub updated_at: u64,
 }
+
+// =============================================================================
+// Canonical Cross-Chain Asset Registry Events
+// =============================================================================
+
+/// Emitted when a new foreign-chain asset mapping is registered.
+#[contractevent]
+#[derive(Clone)]
+pub struct ForeignAssetMappedEvent {
+    #[topic]
+    pub stellar_asset: Address,
+    pub chain: String,
+    pub foreign_address: BytesN<32>,
+    pub decimals: u32,
+}
+
+/// Emitted when an existing foreign-chain asset mapping is updated
+/// (decimals and/or enabled flag).
+#[contractevent]
+#[derive(Clone)]
+pub struct ForeignAssetMappingUpdatedEvent {
+    #[topic]
+    pub stellar_asset: Address,
+    pub chain: String,
+    pub foreign_address: BytesN<32>,
+    pub decimals: u32,
+    pub enabled: bool,
+}
+
+/// Emitted when a foreign-chain asset mapping is removed.
+#[contractevent]
+#[derive(Clone)]
+pub struct ForeignAssetMappingRemovedEvent {
+    #[topic]
+    pub stellar_asset: Address,
+    pub chain: String,
+    pub foreign_address: BytesN<32>,
+}

--- a/contracts/price-oracle/src/events.rs
+++ b/contracts/price-oracle/src/events.rs
@@ -1803,3 +1803,39 @@ pub struct ForeignAssetMappingRemovedEvent {
     pub chain: String,
     pub foreign_address: BytesN<32>,
 }
+
+// =============================================================================
+// Axelar GMP Integration Events
+// =============================================================================
+
+/// Emitted when the trusted Axelar Gateway address is (re)configured.
+#[contractevent]
+#[derive(Clone)]
+pub struct AxelarGatewaySetEvent {
+    #[topic]
+    pub gateway: Address,
+}
+
+/// Emitted when a trusted Axelar GMP source is registered.
+#[contractevent]
+#[derive(Clone)]
+pub struct AxelarTrustedSourceSetEvent {
+    #[topic]
+    pub bridge_source: Address,
+    pub source_chain: String,
+    pub source_address: String,
+}
+
+/// Emitted when a price is applied from a verified Axelar GMP message.
+#[contractevent]
+#[derive(Clone)]
+pub struct AxelarMessageExecutedEvent {
+    #[topic]
+    pub asset: Address,
+    #[topic]
+    pub bridge_source: Address,
+    pub command_id: BytesN<32>,
+    pub source_chain: String,
+    pub source_address: String,
+    pub price: i128,
+}

--- a/contracts/price-oracle/src/layerzero.rs
+++ b/contracts/price-oracle/src/layerzero.rs
@@ -1,0 +1,360 @@
+//! # LayerZero Integration
+//!
+//! Delivers cross-chain price data via a LayerZero OApp `lzReceive`-style
+//! handler, with the endpoint's ordered-delivery guarantee re-checked at
+//! this contract for defense-in-depth (mirroring LayerZero V2's
+//! `OAppReceiver._acceptNonce`).
+//!
+//! ## Trust model
+//!
+//! Mirrors [`crate::axelar_gmp`]: the admin-configured Endpoint address is
+//! the sole trusted caller. A real LayerZero Endpoint has already verified
+//! DVN/executor attestations for the pathway before invoking `lz_receive`,
+//! so this contract only needs to confirm the call truly came from that
+//! Endpoint (`endpoint.require_auth()`) and that `(src_eid, sender)` is an
+//! allow-listed remote OApp.
+//!
+//! ## Ordering
+//!
+//! Each `(src_eid, sender)` pathway has a strictly increasing nonce. A
+//! delivery is accepted only when `nonce == last_nonce + 1`; a replay, gap,
+//! or reorder is rejected with [`ErrorCode::LzNonceOutOfOrder`].
+//!
+//! ## Message format
+//!
+//! `message` bytes use the same [`crate::types::CrossChainPricePayload`]
+//! wire format as the Axelar integration (see [`crate::bridge_common`]).
+//! Because LayerZero identifies source chains by a numeric `src_eid` rather
+//! than the string chain names used elsewhere in the
+//! [`crate::asset_registry`], each `src_eid` is mapped once to its canonical
+//! registry chain name via [`set_lz_chain_name`].
+//!
+//! ## Bridging into existing cross-chain verification
+//!
+//! Applied prices flow through [`crate::bridge_common::apply_bridged_price`],
+//! which records the observation into the existing cross-chain reference
+//! price store ([`crate::cross_chain_verify`]) alongside Axelar-sourced and
+//! admin-submitted observations.
+
+use soroban_sdk::{panic_with_error, Address, Bytes, BytesN, Env, String};
+
+use crate::asset_registry::resolve_enabled_mapping;
+use crate::bridge_common::{apply_bridged_price, decode_price_payload};
+use crate::events::{LzEndpointSetEvent, LzMessageReceivedEvent, LzTrustedRemoteSetEvent};
+use crate::pause::check_not_paused;
+use crate::storage::{check_source, get_admin, LEDGER_BUMP, LEDGER_THRESHOLD};
+use crate::types::{DataKey, ErrorCode};
+
+/// Configures the trusted LayerZero Endpoint contract address. Admin-only.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+pub fn set_layerzero_endpoint(env: &Env, endpoint: Address) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    env.storage().persistent().set(&DataKey::LzEndpoint, &endpoint);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::LzEndpoint, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+    LzEndpointSetEvent { endpoint }.publish(env);
+}
+
+/// Returns the currently configured LayerZero Endpoint address, if any.
+pub fn get_layerzero_endpoint(env: &Env) -> Option<Address> {
+    env.storage().persistent().get(&DataKey::LzEndpoint)
+}
+
+/// Maps a LayerZero source endpoint id onto a canonical
+/// [`crate::asset_registry`] chain name (e.g. `30101 -> "ethereum"`).
+/// Admin-only.
+pub fn set_lz_chain_name(env: &Env, src_eid: u32, chain: String) {
+    let admin = get_admin(env);
+    admin.require_auth();
+
+    let key = DataKey::LzEidChainName(src_eid);
+    env.storage().persistent().set(&key, &chain);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+}
+
+fn read_chain_name(env: &Env, src_eid: u32) -> String {
+    env.storage()
+        .persistent()
+        .get(&DataKey::LzEidChainName(src_eid))
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::LzChainNameNotConfigured))
+}
+
+/// Registers `bridge_source` — an already-registered oracle source (see
+/// [`crate::sources::add_source`]) — as the attribution target for messages
+/// from the `(src_eid, sender)` pathway. Admin-only.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+/// * [`ErrorCode::NotAuthorized`] (via [`check_source`]) — `bridge_source` is
+///   not a registered oracle source.
+pub fn set_trusted_remote(env: &Env, src_eid: u32, sender: BytesN<32>, bridge_source: Address) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    check_source(env, &bridge_source);
+
+    let key = DataKey::LzTrustedRemote(src_eid, sender.clone());
+    env.storage().persistent().set(&key, &bridge_source);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+    LzTrustedRemoteSetEvent {
+        bridge_source,
+        src_eid,
+        sender,
+    }
+    .publish(env);
+}
+
+/// Revokes a trusted LayerZero remote pathway. Admin-only.
+pub fn remove_trusted_remote(env: &Env, src_eid: u32, sender: BytesN<32>) {
+    let admin = get_admin(env);
+    admin.require_auth();
+    env.storage()
+        .persistent()
+        .remove(&DataKey::LzTrustedRemote(src_eid, sender));
+}
+
+fn read_trusted_remote(env: &Env, src_eid: u32, sender: &BytesN<32>) -> Address {
+    env.storage()
+        .persistent()
+        .get(&DataKey::LzTrustedRemote(src_eid, sender.clone()))
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::LzRemoteNotTrusted))
+}
+
+/// Returns the last accepted inbound nonce for a `(src_eid, sender)` pathway,
+/// or `0` if none has been delivered yet.
+pub fn get_inbound_nonce(env: &Env, src_eid: u32, sender: BytesN<32>) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::LzInboundNonce(src_eid, sender))
+        .unwrap_or(0)
+}
+
+/// Delivers a price update via a LayerZero `lzReceive`-style call.
+///
+/// `endpoint` must equal the configured trusted Endpoint address and must
+/// authorize this call — satisfied automatically when the real LayerZero
+/// Endpoint contract invokes this function directly after its own
+/// DVN/executor verification for the pathway.
+///
+/// # Errors
+///
+/// * [`ErrorCode::LzEndpointNotConfigured`] — no Endpoint has been configured.
+/// * [`ErrorCode::NotAuthorized`] — `endpoint` does not match the configured Endpoint.
+/// * [`ErrorCode::LzNonceOutOfOrder`] — `nonce` is not exactly one greater than
+///   the last accepted nonce for this `(src_eid, sender)` pathway.
+/// * [`ErrorCode::LzRemoteNotTrusted`] — no bridge source is registered for
+///   `(src_eid, sender)`.
+/// * [`ErrorCode::LzChainNameNotConfigured`] — `src_eid` has no registry chain name.
+/// * [`ErrorCode::ForeignAssetNotMapped`] / [`ErrorCode::ForeignAssetMappingDisabled`] —
+///   the payload's foreign asset id has no active registry mapping on that chain.
+pub fn lz_receive(
+    env: &Env,
+    endpoint: Address,
+    src_eid: u32,
+    sender: BytesN<32>,
+    nonce: u64,
+    guid: BytesN<32>,
+    message: Bytes,
+) {
+    check_not_paused(env);
+
+    let configured = get_layerzero_endpoint(env)
+        .unwrap_or_else(|| panic_with_error!(env, ErrorCode::LzEndpointNotConfigured));
+    if endpoint != configured {
+        panic_with_error!(env, ErrorCode::NotAuthorized);
+    }
+    endpoint.require_auth();
+
+    let nonce_key = DataKey::LzInboundNonce(src_eid, sender.clone());
+    let last_nonce: u64 = env.storage().persistent().get(&nonce_key).unwrap_or(0);
+    if nonce != last_nonce + 1 {
+        panic_with_error!(env, ErrorCode::LzNonceOutOfOrder);
+    }
+    env.storage().persistent().set(&nonce_key, &nonce);
+    env.storage()
+        .persistent()
+        .extend_ttl(&nonce_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+    let bridge_source = read_trusted_remote(env, src_eid, &sender);
+    let chain = read_chain_name(env, src_eid);
+    let payload = decode_price_payload(env, &message);
+    let mapping = resolve_enabled_mapping(env, &chain, &payload.foreign_asset);
+
+    apply_bridged_price(
+        env,
+        bridge_source.clone(),
+        mapping.stellar_asset.clone(),
+        payload.price,
+        payload.timestamp,
+        payload.decimals,
+        chain,
+    );
+
+    LzMessageReceivedEvent {
+        asset: mapping.stellar_asset,
+        bridge_source,
+        src_eid,
+        sender,
+        nonce,
+        guid,
+        price: payload.price,
+    }
+    .publish(env);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge_common::encode_price_payload;
+    use crate::types::CrossChainPricePayload;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+
+    const ETH_EID: u32 = 30101;
+
+    fn setup(env: &Env) -> (Address, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let asset = Address::generate(env);
+        crate::admin::initialize(env, admin.clone(), 1, 100, 18, String::from_str(env, "Oracle"));
+        crate::assets::register_asset(env, asset.clone());
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+        (admin, asset, Address::generate(env))
+    }
+
+    fn wire_lz(
+        env: &Env,
+        asset: &Address,
+        endpoint: &Address,
+        bridge_source: &Address,
+        sender: &BytesN<32>,
+        chain: &String,
+        foreign_address: &BytesN<32>,
+    ) {
+        crate::sources::add_source(env, bridge_source.clone(), String::from_str(env, "LayerZero"));
+        crate::sources::add_source_asset(env, bridge_source.clone(), asset.clone());
+        set_layerzero_endpoint(env, endpoint.clone());
+        set_lz_chain_name(env, ETH_EID, chain.clone());
+        set_trusted_remote(env, ETH_EID, sender.clone(), bridge_source.clone());
+        crate::asset_registry::register_foreign_asset_mapping(
+            env,
+            asset.clone(),
+            chain.clone(),
+            foreign_address.clone(),
+            18,
+        );
+    }
+
+    #[test]
+    fn test_lz_receive_updates_price_and_nonce() {
+        let env = Env::default();
+        let (_, asset, endpoint) = setup(&env);
+        let bridge_source = Address::generate(&env);
+        let sender = BytesN::from_array(&env, &[21u8; 32]);
+        let chain = String::from_str(&env, "ethereum");
+        let foreign_address = BytesN::from_array(&env, &[22u8; 32]);
+        wire_lz(&env, &asset, &endpoint, &bridge_source, &sender, &chain, &foreign_address);
+
+        let payload = CrossChainPricePayload {
+            foreign_asset: foreign_address,
+            price: 2_000_000_000_000_000_000i128,
+            decimals: 18,
+            timestamp: env.ledger().timestamp(),
+            nonce: 1,
+        };
+        let encoded = encode_price_payload(&env, &payload);
+
+        lz_receive(
+            &env,
+            endpoint,
+            ETH_EID,
+            sender.clone(),
+            1,
+            BytesN::from_array(&env, &[1u8; 32]),
+            encoded,
+        );
+
+        assert_eq!(get_inbound_nonce(&env, ETH_EID, sender.clone()), 1);
+        let entry: crate::types::PriceEntry = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Submission(asset, bridge_source))
+            .unwrap();
+        assert_eq!(entry.price, 2_000_000_000_000_000_000i128);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lz_receive_rejects_out_of_order_nonce() {
+        let env = Env::default();
+        let (_, asset, endpoint) = setup(&env);
+        let bridge_source = Address::generate(&env);
+        let sender = BytesN::from_array(&env, &[23u8; 32]);
+        let chain = String::from_str(&env, "ethereum");
+        let foreign_address = BytesN::from_array(&env, &[24u8; 32]);
+        wire_lz(&env, &asset, &endpoint, &bridge_source, &sender, &chain, &foreign_address);
+
+        let payload = CrossChainPricePayload {
+            foreign_asset: foreign_address,
+            price: 1_000_000_000_000_000_000i128,
+            decimals: 18,
+            timestamp: env.ledger().timestamp(),
+            nonce: 1,
+        };
+        let encoded = encode_price_payload(&env, &payload);
+
+        // Skips nonce 1, jumps straight to 2 — must be rejected.
+        lz_receive(
+            &env,
+            endpoint,
+            ETH_EID,
+            sender,
+            2,
+            BytesN::from_array(&env, &[2u8; 32]),
+            encoded,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lz_receive_rejects_untrusted_endpoint() {
+        let env = Env::default();
+        let (_, asset, endpoint) = setup(&env);
+        let bridge_source = Address::generate(&env);
+        let sender = BytesN::from_array(&env, &[25u8; 32]);
+        let chain = String::from_str(&env, "ethereum");
+        let foreign_address = BytesN::from_array(&env, &[26u8; 32]);
+        wire_lz(&env, &asset, &endpoint, &bridge_source, &sender, &chain, &foreign_address);
+
+        let payload = CrossChainPricePayload {
+            foreign_asset: foreign_address,
+            price: 1_000_000_000_000_000_000i128,
+            decimals: 18,
+            timestamp: env.ledger().timestamp(),
+            nonce: 1,
+        };
+        let encoded = encode_price_payload(&env, &payload);
+        let impostor = Address::generate(&env);
+
+        lz_receive(
+            &env,
+            impostor,
+            ETH_EID,
+            sender,
+            1,
+            BytesN::from_array(&env, &[3u8; 32]),
+            encoded,
+        );
+    }
+}

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -106,6 +106,11 @@ mod asset_registry;
 // =============================================================================
 mod axelar_gmp;
 
+// =============================================================================
+// LayerZero Integration
+// =============================================================================
+mod layerzero;
+
 // Shared wire format / submission plumbing used by the bridge integrations above.
 mod bridge_common;
 
@@ -4965,6 +4970,68 @@ impl PriceOracleContract {
             source_address,
             payload,
         );
+    }
+
+    // --- LayerZero integration ---
+
+    /// Configures the trusted LayerZero Endpoint contract address. Admin-only.
+    pub fn set_layerzero_endpoint(env: Env, endpoint: Address) {
+        layerzero::set_layerzero_endpoint(&env, endpoint);
+    }
+
+    /// Returns the currently configured LayerZero Endpoint address, if any.
+    pub fn get_layerzero_endpoint(env: Env) -> Option<Address> {
+        layerzero::get_layerzero_endpoint(&env)
+    }
+
+    /// Maps a LayerZero source endpoint id onto a canonical registry chain name
+    /// (e.g. `30101 -> "ethereum"`). Admin-only.
+    pub fn set_lz_chain_name(env: Env, src_eid: u32, chain: String) {
+        layerzero::set_lz_chain_name(&env, src_eid, chain);
+    }
+
+    /// Registers `bridge_source` (an already-registered oracle source) as the
+    /// attribution target for messages from the `(src_eid, sender)` pathway.
+    /// Admin-only.
+    pub fn set_lz_trusted_remote(env: Env, src_eid: u32, sender: BytesN<32>, bridge_source: Address) {
+        layerzero::set_trusted_remote(&env, src_eid, sender, bridge_source);
+    }
+
+    /// Revokes a trusted LayerZero remote pathway. Admin-only.
+    pub fn remove_lz_trusted_remote(env: Env, src_eid: u32, sender: BytesN<32>) {
+        layerzero::remove_trusted_remote(&env, src_eid, sender);
+    }
+
+    /// Returns the last accepted inbound nonce for a `(src_eid, sender)` pathway (`0` if none).
+    pub fn get_lz_inbound_nonce(env: Env, src_eid: u32, sender: BytesN<32>) -> u64 {
+        layerzero::get_inbound_nonce(&env, src_eid, sender)
+    }
+
+    /// Delivers a price update via a LayerZero `lzReceive`-style call. `endpoint`
+    /// must match the configured trusted Endpoint address and authorize this
+    /// call. Nonce ordering is strictly enforced per `(src_eid, sender)` pathway.
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::LzEndpointNotConfigured`] — no Endpoint has been configured.
+    /// * [`ErrorCode::NotAuthorized`] — `endpoint` does not match the configured Endpoint.
+    /// * [`ErrorCode::LzNonceOutOfOrder`] — `nonce` is not exactly one greater than
+    ///   the last accepted nonce for this pathway.
+    /// * [`ErrorCode::LzRemoteNotTrusted`] — no bridge source is registered for
+    ///   `(src_eid, sender)`.
+    /// * [`ErrorCode::LzChainNameNotConfigured`] — `src_eid` has no registry chain name.
+    /// * [`ErrorCode::ForeignAssetNotMapped`] — the payload's foreign asset id has no
+    ///   registry mapping on that chain.
+    pub fn lz_receive(
+        env: Env,
+        endpoint: Address,
+        src_eid: u32,
+        sender: BytesN<32>,
+        nonce: u64,
+        guid: BytesN<32>,
+        message: Bytes,
+    ) {
+        layerzero::lz_receive(&env, endpoint, src_eid, sender, nonce, guid, message);
     }
 }
 

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -101,6 +101,19 @@ mod event_streaming;
 // =============================================================================
 mod asset_registry;
 
+// =============================================================================
+// Axelar GMP Integration
+// =============================================================================
+mod axelar_gmp;
+
+// Shared wire format / submission plumbing used by the bridge integrations above.
+mod bridge_common;
+
+// #226 — Cross-chain reference-price verification. Existed on disk but was never
+// wired into the crate (same class of dropped-wiring bug called out at the top of
+// this file); wired in now because `bridge_common` extends it for Axelar/LayerZero.
+mod cross_chain_verify;
+
 #[cfg(test)]
 mod circuit_breaker_tests;
 
@@ -199,8 +212,10 @@ pub use types::{
     StateDump, StateAnalysis, StateDiff, StateDiffEntry,
     // DEX / AMM integration
     DexPrice, AmmWeightConfig, SoroswapPool,
-    // Cross-chain asset registry
-    ForeignAssetMapping,
+    // Cross-chain asset registry & bridge message format
+    ForeignAssetMapping, CrossChainPricePayload,
+    // Cross-chain reference-price verification (#226)
+    CrossChainPriceEntry,
 };
 
 use soroban_sdk::{
@@ -4833,6 +4848,123 @@ impl PriceOracleContract {
     /// Returns every foreign-chain mapping registered for `asset`.
     pub fn get_foreign_mappings_for_asset(env: Env, asset: Address) -> Vec<ForeignAssetMapping> {
         asset_registry::get_foreign_mappings_for_asset(&env, asset)
+    }
+
+    // --- #226: Cross-chain reference-price verification ---
+
+    /// Enables or disables cross-chain reference-price verification globally. Admin-only.
+    pub fn set_cross_chain_verification_enabled(env: Env, enabled: bool) {
+        cross_chain_verify::set_cross_chain_verification_enabled(&env, enabled);
+    }
+
+    /// Returns whether cross-chain reference-price verification is enabled.
+    pub fn is_cross_chain_verification_enabled(env: Env) -> bool {
+        cross_chain_verify::is_cross_chain_verification_enabled(&env)
+    }
+
+    /// Sets the maximum allowed deviation (basis points) between this oracle's
+    /// price and a reference chain's price. Admin-only.
+    pub fn set_cross_chain_deviation_threshold(env: Env, threshold_bps: u32) {
+        cross_chain_verify::set_cross_chain_deviation_threshold(&env, threshold_bps);
+    }
+
+    /// Returns the current cross-chain deviation threshold in basis points.
+    pub fn get_cross_chain_deviation_threshold(env: Env) -> u32 {
+        cross_chain_verify::get_cross_chain_deviation_threshold(&env)
+    }
+
+    /// Records a reference price for `asset` observed on `oracle_chain`, for later
+    /// verification against this oracle's own aggregate. Admin-only.
+    pub fn submit_cross_chain_price(
+        env: Env,
+        asset: Address,
+        oracle_chain: Address,
+        price: i128,
+        decimals: u32,
+        chain_id: String,
+        timestamp: u64,
+    ) {
+        cross_chain_verify::submit_cross_chain_price(
+            &env,
+            asset,
+            oracle_chain,
+            price,
+            decimals,
+            chain_id,
+            timestamp,
+        );
+    }
+
+    /// Returns the most recent recorded cross-chain reference price for `asset`
+    /// from `oracle_chain`, if any (includes prices recorded by the Axelar/LayerZero
+    /// bridge integrations, not only [`Self::submit_cross_chain_price`]).
+    pub fn get_cross_chain_price(
+        env: Env,
+        asset: Address,
+        oracle_chain: Address,
+    ) -> Option<CrossChainPriceEntry> {
+        cross_chain_verify::get_cross_chain_price(&env, &asset, &oracle_chain)
+    }
+
+    // --- Axelar GMP integration ---
+
+    /// Configures the trusted Axelar Gateway contract address. Admin-only.
+    pub fn set_axelar_gateway(env: Env, gateway: Address) {
+        axelar_gmp::set_axelar_gateway(&env, gateway);
+    }
+
+    /// Returns the currently configured Axelar Gateway address, if any.
+    pub fn get_axelar_gateway(env: Env) -> Option<Address> {
+        axelar_gmp::get_axelar_gateway(&env)
+    }
+
+    /// Registers `bridge_source` (an already-registered oracle source) as the
+    /// attribution target for GMP messages from `(source_chain, source_address)`.
+    /// Admin-only.
+    pub fn set_axelar_trusted_source(
+        env: Env,
+        source_chain: String,
+        source_address: String,
+        bridge_source: Address,
+    ) {
+        axelar_gmp::set_axelar_trusted_source(&env, source_chain, source_address, bridge_source);
+    }
+
+    /// Revokes a trusted Axelar GMP source. Admin-only.
+    pub fn remove_axelar_trusted_source(env: Env, source_chain: String, source_address: String) {
+        axelar_gmp::remove_axelar_trusted_source(&env, source_chain, source_address);
+    }
+
+    /// Delivers a price update relayed over Axelar GMP. `gateway` must match the
+    /// configured trusted Gateway address and authorize this call — satisfied
+    /// automatically when the real Axelar Gateway contract invokes this function
+    /// directly after its own verifier-set quorum check has approved the message.
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::AxelarGatewayNotConfigured`] — no Gateway has been configured.
+    /// * [`ErrorCode::NotAuthorized`] — `gateway` does not match the configured Gateway.
+    /// * [`ErrorCode::AxelarCommandAlreadyExecuted`] — `command_id` was already processed.
+    /// * [`ErrorCode::AxelarSourceNotTrusted`] — no bridge source is registered for
+    ///   `(source_chain, source_address)`.
+    /// * [`ErrorCode::ForeignAssetNotMapped`] — the payload's foreign asset id has no
+    ///   registry mapping on `source_chain`.
+    pub fn execute_axelar_message(
+        env: Env,
+        gateway: Address,
+        command_id: BytesN<32>,
+        source_chain: String,
+        source_address: String,
+        payload: Bytes,
+    ) {
+        axelar_gmp::execute_axelar_message(
+            &env,
+            gateway,
+            command_id,
+            source_chain,
+            source_address,
+            payload,
+        );
     }
 }
 

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -96,6 +96,11 @@ mod ecosystem_metadata;
 // =============================================================================
 mod event_streaming;
 
+// =============================================================================
+// Canonical Cross-Chain Asset Registry
+// =============================================================================
+mod asset_registry;
+
 #[cfg(test)]
 mod circuit_breaker_tests;
 
@@ -194,6 +199,8 @@ pub use types::{
     StateDump, StateAnalysis, StateDiff, StateDiffEntry,
     // DEX / AMM integration
     DexPrice, AmmWeightConfig, SoroswapPool,
+    // Cross-chain asset registry
+    ForeignAssetMapping,
 };
 
 use soroban_sdk::{
@@ -4770,6 +4777,62 @@ impl PriceOracleContract {
     /// Returns feed metadata for a specific asset, or `None`.
     pub fn metadata_get_feed(env: Env, asset: Address) -> Option<FeedMetadata> {
         ecosystem_metadata::get_feed_metadata(&env, asset)
+    }
+
+    // --- Canonical cross-chain asset registry ---
+
+    /// Registers a canonical mapping from `stellar_asset` to its representation
+    /// on a foreign `chain`. Admin-only. See [`crate::asset_registry`].
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+    /// * [`ErrorCode::AssetNotRegistered`] — `stellar_asset` is not registered.
+    /// * [`ErrorCode::ForeignAssetAlreadyMapped`] — a mapping already exists.
+    pub fn register_foreign_asset_mapping(
+        env: Env,
+        stellar_asset: Address,
+        chain: String,
+        foreign_address: BytesN<32>,
+        decimals: u32,
+    ) {
+        asset_registry::register_foreign_asset_mapping(
+            &env,
+            stellar_asset,
+            chain,
+            foreign_address,
+            decimals,
+        );
+    }
+
+    /// Updates an existing foreign asset mapping's decimals and enabled flag. Admin-only.
+    pub fn update_foreign_asset_mapping(
+        env: Env,
+        chain: String,
+        foreign_address: BytesN<32>,
+        decimals: u32,
+        enabled: bool,
+    ) {
+        asset_registry::update_foreign_asset_mapping(&env, chain, foreign_address, decimals, enabled);
+    }
+
+    /// Removes a foreign asset mapping. Admin-only.
+    pub fn remove_foreign_asset_mapping(env: Env, chain: String, foreign_address: BytesN<32>) {
+        asset_registry::remove_foreign_asset_mapping(&env, chain, foreign_address);
+    }
+
+    /// Returns the mapping for `(chain, foreign_address)`, if any.
+    pub fn get_foreign_asset_mapping(
+        env: Env,
+        chain: String,
+        foreign_address: BytesN<32>,
+    ) -> Option<ForeignAssetMapping> {
+        asset_registry::get_foreign_asset_mapping(&env, chain, foreign_address)
+    }
+
+    /// Returns every foreign-chain mapping registered for `asset`.
+    pub fn get_foreign_mappings_for_asset(env: Env, asset: Address) -> Vec<ForeignAssetMapping> {
+        asset_registry::get_foreign_mappings_for_asset(&env, asset)
     }
 }
 

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -1290,7 +1290,10 @@ pub fn get_aggregate_with_version(
     crate::types::VersionedAggregatePrice { aggregate, version }
 }
 
-
+/// Returns the current aggregated price for `asset` together with a confidence
+/// score in basis points derived from the dispersion of contributing sources'
+/// last submitted prices (#252 — see [`compute_confidence_bps`]).
+pub fn get_price_with_confidence(env: &Env, asset: Address) -> Option<(AggregatePrice, u32)> {
     let aggregate = get_price(env, asset.clone(), 0)?;
 
     let mut prices: Vec<i128> = Vec::new(env);

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -562,6 +562,16 @@ pub enum DataKey {
     // -------------------------------------------------------------------------
     /// Stellar ecosystem metadata registry entry.
     EcosystemMetadata,
+
+    // -------------------------------------------------------------------------
+    // Canonical cross-chain asset registry
+    // -------------------------------------------------------------------------
+    /// Canonical [`ForeignAssetMapping`] keyed by (chain identifier, foreign asset id).
+    ForeignAssetMapping(String, BytesN<32>),
+    /// Ordered list of (chain, foreign_address) keys registered for a Stellar asset.
+    AssetForeignMappings(Address),
+    /// Global ordered list of all (chain, foreign_address) keys, for enumeration.
+    ForeignAssetRegistryList,
 }
 
 /// A price submission from a single oracle source for a specific asset.
@@ -2182,6 +2192,32 @@ pub struct SoroswapPool {
     pub reserve_a: i128,
     pub reserve_b: i128,
     pub fee_bps: u32,
+    pub enabled: bool,
+}
+
+// =============================================================================
+// Canonical Cross-Chain Asset Registry
+// =============================================================================
+
+/// Canonical mapping from a Stellar asset to its representation on a foreign chain.
+///
+/// Keyed by `(chain, foreign_address)` — see [`crate::asset_registry`]. All
+/// cross-chain integrations (Axelar GMP, LayerZero, manual cross-reference
+/// checks) resolve foreign asset identifiers through this single registry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ForeignAssetMapping {
+    /// The Stellar asset address this mapping resolves to.
+    pub stellar_asset: Address,
+    /// Canonical chain identifier (e.g. `"ethereum"`, `"polygon"`).
+    pub chain: String,
+    /// 32-byte canonical representation of the asset's address on `chain`
+    /// (shorter addresses, e.g. 20-byte EVM addresses, are left-padded).
+    pub foreign_address: BytesN<32>,
+    /// Decimal precision of the price/amount as denominated on `chain`.
+    pub decimals: u32,
+    /// Whether this mapping is currently active. Disabled mappings are kept
+    /// for history but rejected by cross-chain modules.
     pub enabled: bool,
 }
 

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -572,6 +572,16 @@ pub enum DataKey {
     AssetForeignMappings(Address),
     /// Global ordered list of all (chain, foreign_address) keys, for enumeration.
     ForeignAssetRegistryList,
+
+    // -------------------------------------------------------------------------
+    // Axelar GMP integration
+    // -------------------------------------------------------------------------
+    /// Trusted Axelar Gateway contract address permitted to invoke `execute_axelar_message`.
+    AxelarGateway,
+    /// Replay-protection flag for a processed Axelar `command_id`.
+    AxelarExecutedCommand(BytesN<32>),
+    /// Maps a trusted (source_chain, source_address) GMP sender to a registered bridge source.
+    AxelarTrustedSource(String, String),
 }
 
 /// A price submission from a single oracle source for a specific asset.
@@ -2219,5 +2229,32 @@ pub struct ForeignAssetMapping {
     /// Whether this mapping is currently active. Disabled mappings are kept
     /// for history but rejected by cross-chain modules.
     pub enabled: bool,
+}
+
+// =============================================================================
+// Cross-Chain Bridge Message Format (Axelar GMP / LayerZero)
+// =============================================================================
+
+/// Canonical cross-chain price update payload shared by every bridge
+/// integration (Axelar GMP, LayerZero, ...), so a single wire format is
+/// used regardless of which transport carried the message.
+///
+/// Encoded on the wire (see [`crate::bridge_common`]) as the 68-byte
+/// concatenation `foreign_asset(32) || price_le(16) || decimals_le(4) ||
+/// timestamp_le(8) || nonce_le(8)`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CrossChainPricePayload {
+    /// Foreign-chain asset identifier, resolved via the asset registry.
+    pub foreign_asset: BytesN<32>,
+    /// Raw price value scaled by `10^decimals`.
+    pub price: i128,
+    /// Decimal precision of `price` as observed on the source chain.
+    pub decimals: u32,
+    /// Unix timestamp (seconds) of the price observation on the source chain.
+    pub timestamp: u64,
+    /// Sender-assigned nonce, carried for auditability (ordering itself is
+    /// enforced by the transport, e.g. LayerZero's per-pathway nonce).
+    pub nonce: u64,
 }
 

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -582,6 +582,18 @@ pub enum DataKey {
     AxelarExecutedCommand(BytesN<32>),
     /// Maps a trusted (source_chain, source_address) GMP sender to a registered bridge source.
     AxelarTrustedSource(String, String),
+
+    // -------------------------------------------------------------------------
+    // LayerZero integration
+    // -------------------------------------------------------------------------
+    /// Trusted LayerZero Endpoint contract address permitted to invoke `lz_receive`.
+    LzEndpoint,
+    /// Last accepted inbound nonce for a (source endpoint id, sender) pathway.
+    LzInboundNonce(u32, BytesN<32>),
+    /// Maps a trusted (src_eid, sender) LayerZero pathway to a registered bridge source.
+    LzTrustedRemote(u32, BytesN<32>),
+    /// Canonical registry chain name for a LayerZero source endpoint id.
+    LzEidChainName(u32),
 }
 
 /// A price submission from a single oracle source for a specific asset.

--- a/docs/signed-price-adapters.md
+++ b/docs/signed-price-adapters.md
@@ -1,0 +1,110 @@
+# Signed CEX / Aggregator Price Adapters
+
+Off-chain adapter connectors that feed reference prices from centralized
+exchanges and price aggregators (CoinGecko, Binance, Coinbase) into the
+oracle through the existing signed-submission path
+([`submit_price_with_proof`](../contracts/price-oracle/src/signed_submission.rs),
+#216) instead of a plain `require_auth` transaction. The registered
+source's Ed25519 key signs each price observation off-chain; any address
+may then relay the resulting call on-chain, so the source itself never has
+to hold gas or submit a transaction directly.
+
+## Why signed submission instead of `submit_price`
+
+[`scripts/price-submission-bot.py`](../scripts/price-submission-bot.py)
+already submits prices via the source's own Soroban-authorized
+transaction. This adapter is a separate, purpose-built connector for
+first-party CEX/aggregator feeds that:
+
+* signs each observation with a long-lived Ed25519 key instead of
+  requiring the source's Stellar account to co-sign every submission, and
+* can be relayed by an unrelated, disposable "gas payer" identity —
+  useful for running the signer offline/air-gapped from the relaying
+  infrastructure.
+
+## Provider failover
+
+Each asset lists its providers in priority order (`providers` in the
+config). On every cycle the adapter tries them in order and uses the
+**first** one that returns a usable price:
+
+```
+CoinGecko (primary) → Binance (fallback) → Coinbase (fallback)
+```
+
+A provider is skipped, and the next one tried, when:
+
+* the HTTP request fails, times out, or returns an unparseable response
+  (network blip, rate limit, provider outage), or
+* the provider's own reported observation time is older than
+  `max_staleness_secs` (currently only CoinGecko's
+  `include_last_updated_at` exposes this — see below).
+
+If every configured provider fails or is stale, the adapter **skips the
+submission cycle entirely** rather than resubmitting a cached price under
+a fresh timestamp, which would misrepresent how current the data is. This
+is logged and counted in `no_price_available_total`; a monitoring stack
+should alert on this metric being nonzero for longer than the asset's
+normal update cadence.
+
+## Staleness handling
+
+* **CoinGecko** exposes `last_updated_at` (Unix seconds) per asset via
+  `include_last_updated_at=true`. The adapter rejects a CoinGecko price
+  older than `max_staleness_secs` and fails over to the next provider,
+  even though the HTTP call itself succeeded.
+* **Binance** and **Coinbase**'s spot endpoints don't expose an
+  observation timestamp; the adapter treats a successful response as
+  current (request time = observation time), which is reasonable for a
+  live ticker/spot endpoint queried on a short interval.
+* Independently of any single provider, `submit_price_with_proof`'s own
+  `timestamp` argument is the adapter's wall-clock time at submission, and
+  the contract separately rejects timestamps too far in the future
+  (`CfgTimestampThreshold`) — this adapter policy only prevents *silently
+  relaying old data as fresh*, it does not replace that on-chain check.
+
+## Replay protection & signed proof expiry
+
+* Each source's `nonce` is tracked locally in `state.nonce_file` (JSON) so
+  it survives adapter restarts and strictly increases, matching the
+  contract's `nonce > last_accepted_nonce` requirement.
+* `expiration_ledger` is computed each cycle as `current ledger +
+  expiration_window_ledgers`, bounding how long a relayer has to land the
+  transaction before the proof goes stale on-chain.
+
+## One-time source setup
+
+1. Register the source (admin, once): `add_source(source_address, name)`.
+2. Generate a 32-byte Ed25519 seed and store it as a hex string in the
+   environment variable named by `ed25519_seed_env`:
+   ```bash
+   export ADAPTER_ED25519_SEED=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+   ```
+3. Register the corresponding public key on-chain (source-authorized
+   transaction, run once):
+   ```bash
+   python3 scripts/signed_price_adapter.py --config signed_adapter_config.toml --register-key
+   ```
+
+## Running
+
+```bash
+pip install -r scripts/requirements.txt
+export ADAPTER_ED25519_SEED=...
+python3 scripts/signed_price_adapter.py --config signed_adapter_config.toml
+```
+
+Health and metrics are exposed at `GET /health` on `health.port`
+(`{"status": "ok", "metrics": {...}}`), tracking per-provider fetch
+errors, stale-skip counts, failover events, and submission counts —
+see [`scripts/signed_adapter_config.example.toml`](../scripts/signed_adapter_config.example.toml)
+for the full configuration schema.
+
+## Adding another provider
+
+Add an entry to `PROVIDER_FETCHERS` in
+[`scripts/signed_price_adapter.py`](../scripts/signed_price_adapter.py)
+returning `(price: float, observed_at: int | None)`, then reference it in
+an asset's `providers`/`feed_ids` config. Return `None` for `observed_at`
+if the provider doesn't expose an update timestamp — the adapter falls
+back to treating the request time as the observation time.

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,5 @@
 # Off-chain executor service dependencies
 stellar-sdk==11.0.0
 requests==2.32.3
+# Ed25519 signing for the signed-submission price adapter (#216)
+pynacl==1.5.0

--- a/scripts/signed_adapter_config.example.toml
+++ b/scripts/signed_adapter_config.example.toml
@@ -1,0 +1,48 @@
+[oracle]
+contract_id = "CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+network     = "testnet"
+rpc_url     = "https://soroban-testnet.stellar.org"
+decimals    = 14  # must match the oracle's configured decimals
+
+[source]
+# Stellar address of the oracle source this adapter signs on behalf of.
+# Must already be registered via add_source, and have called
+# register_submission_key with this seed's public key (see
+# `--register-key`, or docs/signed-price-adapters.md).
+address           = "GSOURCE..."
+# CLI identity used only to pay the relaying transaction fee — it does NOT
+# need to be the source's own key, since the signed proof carries the
+# source's authority. May be the same as `identity` below for simplicity.
+relayer_identity  = "default"
+# Stellar CLI identity matching `address`, used solely by --register-key.
+identity          = "oracle-source"
+# Name of the environment variable holding the Ed25519 signing seed as a
+# 64-character hex string. Never put the raw seed in this file.
+ed25519_seed_env  = "ADAPTER_ED25519_SEED"
+
+[state]
+nonce_file = "adapter_nonces.json"
+
+[health]
+port = 9101
+
+[schedule]
+interval_secs              = 30   # default submission interval, overridable per asset
+max_staleness_secs         = 120  # reject a provider's price older than this
+expiration_window_ledgers  = 100  # signed proof validity window (~500s at 5s/ledger)
+
+[assets.BTC]
+contract_address = "CBTC..."
+providers         = ["coingecko", "binance", "coinbase"]  # priority order
+[assets.BTC.feed_ids]
+coingecko = "bitcoin"
+binance   = "BTCUSDT"
+coinbase  = "BTC-USD"
+
+[assets.ETH]
+contract_address = "CETH..."
+providers         = ["coingecko", "binance", "coinbase"]
+[assets.ETH.feed_ids]
+coingecko = "ethereum"
+binance   = "ETHUSDT"
+coinbase  = "ETH-USD"

--- a/scripts/signed_price_adapter.py
+++ b/scripts/signed_price_adapter.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Signed off-chain adapter for centralized-exchange / aggregator price feeds.
+
+Fetches prices for configured assets from first-party CEX/aggregator
+connectors (CoinGecko, Binance, Coinbase), with per-asset provider failover
+and staleness handling, then submits each observation through the existing
+signed-submission path (#216: `submit_price_with_proof`) instead of a
+plain `require_auth` transaction — so the registered source's Ed25519 key
+signs the price off-chain and *any* address may relay the resulting
+transaction on-chain.
+
+See docs/signed-price-adapters.md for the full design, the provider
+failover/staleness policy, and one-time source setup (registering the
+Ed25519 submission key via `register_submission_key`).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import time
+import tomllib
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Lock, Thread
+from typing import Optional
+
+import requests
+from nacl.signing import SigningKey
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("signed-price-adapter")
+
+METRICS = {
+    "submissions_total": 0,
+    "submission_errors_total": 0,
+    "fetch_errors_total": {"coingecko": 0, "binance": 0, "coinbase": 0},
+    "stale_skips_total": {"coingecko": 0, "binance": 0, "coinbase": 0},
+    "failover_events_total": 0,
+    "no_price_available_total": 0,
+    "last_submission_ts": {},
+    "last_provider_used": {},
+}
+
+# Each fetcher returns (price, observed_at_unix_ts | None). `observed_at`
+# is the provider's own reported update time when available (CoinGecko);
+# providers that don't expose one return None and the caller treats the
+# request time as the observation time.
+PROVIDER_FETCHERS = {
+    "coingecko": lambda feed_id: _fetch_coingecko(feed_id),
+    "binance": lambda feed_id: (float(requests.get(
+        "https://api.binance.com/api/v3/ticker/price",
+        params={"symbol": feed_id}, timeout=10,
+    ).json()["price"]), None),
+    "coinbase": lambda feed_id: (float(requests.get(
+        f"https://api.coinbase.com/v2/prices/{feed_id}/spot", timeout=10,
+    ).json()["data"]["amount"]), None),
+}
+
+
+def _fetch_coingecko(feed_id: str) -> tuple[float, Optional[int]]:
+    resp = requests.get(
+        "https://api.coingecko.com/api/v3/simple/price",
+        params={"ids": feed_id, "vs_currencies": "usd", "include_last_updated_at": "true"},
+        timeout=10,
+    ).json()
+    entry = resp[feed_id]
+    return float(entry["usd"]), entry.get("last_updated_at")
+
+
+@dataclass
+class AssetConfig:
+    contract_address: str
+    providers: list = field(default_factory=list)  # priority-ordered
+    feed_ids: dict = field(default_factory=dict)  # provider -> feed id
+    interval_secs: int = 30
+
+
+class NonceStore:
+    """Persists the last accepted nonce per source across restarts.
+
+    `submit_price_with_proof` requires a strictly increasing nonce; losing
+    track of it across a restart (or racing two adapter instances for the
+    same source) would produce rejected submissions, so state is flushed to
+    disk after every increment.
+    """
+
+    def __init__(self, path: str):
+        self._path = path
+        self._lock = Lock()
+        self._nonces: dict[str, int] = {}
+        if os.path.exists(path):
+            with open(path) as f:
+                self._nonces = json.load(f)
+
+    def next(self, source_address: str) -> int:
+        with self._lock:
+            nonce = self._nonces.get(source_address, 0) + 1
+            self._nonces[source_address] = nonce
+            with open(self._path, "w") as f:
+                json.dump(self._nonces, f)
+            return nonce
+
+
+def sign_price_proof(seed_hex: str, nonce: int, price: int, timestamp: int,
+                      expiration_ledger: int) -> tuple[str, str]:
+    """Reproduces contracts/price-oracle/src/signed_submission.rs's digest and
+    signs it, returning (public_key_hex, signature_hex).
+
+    Digest: sha256(b"price_proof_v1" || nonce_le(8) || price_le(16, as u128)
+                   || timestamp_le(8) || expiration_ledger_le(4))
+    """
+    signing_key = SigningKey(bytes.fromhex(seed_hex))
+    buf = (
+        b"price_proof_v1"
+        + nonce.to_bytes(8, "little")
+        + price.to_bytes(16, "little", signed=False)
+        + timestamp.to_bytes(8, "little")
+        + expiration_ledger.to_bytes(4, "little")
+    )
+    digest = hashlib.sha256(buf).digest()
+    signature = signing_key.sign(digest).signature
+    return signing_key.verify_key.encode().hex(), signature.hex()
+
+
+def fetch_with_failover(asset_name: str, asset: AssetConfig, max_staleness_secs: int
+                         ) -> Optional[tuple[float, str]]:
+    """Tries each configured provider in priority order, skipping one that
+    errors or reports a price older than `max_staleness_secs`. Returns the
+    first usable (price, provider_name), or None if every provider failed.
+    """
+    now = int(time.time())
+    for i, provider in enumerate(asset.providers):
+        feed_id = asset.feed_ids.get(provider)
+        fetcher = PROVIDER_FETCHERS.get(provider)
+        if not feed_id or not fetcher:
+            continue
+        try:
+            price, observed_at = fetcher(feed_id)
+        except Exception as exc:  # noqa: BLE001 - one provider's outage must not block failover
+            METRICS["fetch_errors_total"][provider] += 1
+            log.warning("%s: fetch failed from %s: %s", asset_name, provider, exc)
+            continue
+
+        if observed_at is not None and now - observed_at > max_staleness_secs:
+            METRICS["stale_skips_total"][provider] += 1
+            log.warning("%s: %s price is stale (%ds old, max %ds) — trying next provider",
+                        asset_name, provider, now - observed_at, max_staleness_secs)
+            continue
+
+        if i > 0:
+            METRICS["failover_events_total"] += 1
+            log.info("%s: failed over to provider %s", asset_name, provider)
+        return price, provider
+
+    return None
+
+
+def submit_price_with_proof(contract_id: str, network: str, relayer_identity: str,
+                             source_address: str, asset_address: str, price: int,
+                             timestamp: int, nonce: int, expiration_ledger: int,
+                             signature_hex: str, retries: int = 3) -> bool:
+    """Relays a pre-signed price proof on-chain. `relayer_identity` only pays
+    the transaction fee — the signed proof carries the source's authority
+    (verified on-chain against the key registered via `register_submission_key`),
+    so the relaying identity need not be the registered source itself.
+    """
+    for attempt in range(1, retries + 1):
+        try:
+            subprocess.run(
+                [
+                    "stellar", "contract", "invoke",
+                    "--id", contract_id, "--source", relayer_identity, "--network", network,
+                    "--", "submit_price_with_proof",
+                    "--source", source_address,
+                    "--asset", asset_address,
+                    "--price", str(price),
+                    "--timestamp", str(timestamp),
+                    "--nonce", str(nonce),
+                    "--expiration_ledger", str(expiration_ledger),
+                    "--signature", signature_hex,
+                ],
+                check=True, capture_output=True, timeout=30,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 - retry regardless of failure kind
+            backoff = 2 ** attempt
+            log.warning("submit attempt %d/%d failed: %s (retrying in %ds)", attempt, retries, exc, backoff)
+            time.sleep(backoff)
+    return False
+
+
+def get_latest_ledger(rpc_url: str) -> int:
+    from stellar_sdk import SorobanServer
+    with SorobanServer(rpc_url) as server:
+        return server.get_latest_ledger().sequence
+
+
+def register_submission_key(contract_id: str, network: str, source_identity: str, seed_hex: str) -> None:
+    """One-time setup: registers the adapter's Ed25519 public key on-chain for
+    `source_identity` (a normal Soroban-authorized transaction, unrelated to
+    the per-submission proof signature)."""
+    signing_key = SigningKey(bytes.fromhex(seed_hex))
+    public_key_hex = signing_key.verify_key.encode().hex()
+    subprocess.run(
+        [
+            "stellar", "contract", "invoke",
+            "--id", contract_id, "--source", source_identity, "--network", network,
+            "--", "register_submission_key",
+            "--source", source_identity,
+            "--public_key", public_key_hex,
+        ],
+        check=True,
+    )
+    log.info("registered submission key %s for source %s", public_key_hex, source_identity)
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "ok", "metrics": METRICS}).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, fmt, *args):  # silence default request logging
+        pass
+
+
+def run_health_server(port: int) -> None:
+    HTTPServer(("0.0.0.0", port), HealthHandler).serve_forever()
+
+
+def run_asset_loop(contract_id: str, network: str, relayer_identity: str, source_address: str,
+                    seed_hex: str, rpc_url: str, expiration_window_ledgers: int,
+                    max_staleness_secs: int, decimals: int, nonces: NonceStore,
+                    asset_name: str, asset: AssetConfig) -> None:
+    while True:
+        result = fetch_with_failover(asset_name, asset, max_staleness_secs)
+        if result is None:
+            METRICS["no_price_available_total"] += 1
+            log.error("%s: no provider returned a usable price this cycle", asset_name)
+            time.sleep(asset.interval_secs)
+            continue
+
+        price, provider = result
+        METRICS["last_provider_used"][asset_name] = provider
+        scaled_price = int(price * 10**decimals)
+        timestamp = int(time.time())
+        nonce = nonces.next(source_address)
+
+        try:
+            expiration_ledger = get_latest_ledger(rpc_url) + expiration_window_ledgers
+        except Exception as exc:  # noqa: BLE001 - RPC hiccup shouldn't crash the loop
+            log.error("%s: failed to fetch latest ledger: %s", asset_name, exc)
+            time.sleep(asset.interval_secs)
+            continue
+
+        _, signature_hex = sign_price_proof(
+            seed_hex, nonce, scaled_price, timestamp, expiration_ledger,
+        )
+
+        ok = submit_price_with_proof(
+            contract_id, network, relayer_identity, source_address, asset.contract_address,
+            scaled_price, timestamp, nonce, expiration_ledger, signature_hex,
+        )
+        if ok:
+            METRICS["submissions_total"] += 1
+            METRICS["last_submission_ts"][asset_name] = timestamp
+            log.info("%s: submitted %s (via %s, nonce=%d)", asset_name, price, provider, nonce)
+        else:
+            METRICS["submission_errors_total"] += 1
+            log.error("%s: submission failed after retries", asset_name)
+
+        time.sleep(asset.interval_secs)
+
+
+def load_config(path: str) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=os.environ.get("ADAPTER_CONFIG", "signed_adapter_config.toml"))
+    parser.add_argument("--register-key", action="store_true",
+                         help="Register the source's Ed25519 submission key on-chain and exit.")
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    oracle = config["oracle"]
+    source = config["source"]
+    seed_hex = os.environ[source["ed25519_seed_env"]]
+
+    if args.register_key:
+        register_submission_key(oracle["contract_id"], oracle["network"], source["identity"], seed_hex)
+        return
+
+    nonces = NonceStore(config.get("state", {}).get("nonce_file", "adapter_nonces.json"))
+    health_port = int(config.get("health", {}).get("port", 9101))
+    schedule = config.get("schedule", {})
+    max_staleness_secs = int(schedule.get("max_staleness_secs", 120))
+    expiration_window_ledgers = int(schedule.get("expiration_window_ledgers", 100))
+    decimals = int(oracle.get("decimals", 14))
+
+    Thread(target=run_health_server, args=(health_port,), daemon=True).start()
+    log.info("health endpoint listening on :%d", health_port)
+
+    threads = []
+    for asset_name, asset_cfg in config["assets"].items():
+        asset = AssetConfig(
+            contract_address=asset_cfg["contract_address"],
+            providers=asset_cfg["providers"],
+            feed_ids=asset_cfg["feed_ids"],
+            interval_secs=asset_cfg.get("interval_secs", schedule.get("interval_secs", 30)),
+        )
+        t = Thread(
+            target=run_asset_loop,
+            args=(oracle["contract_id"], oracle["network"], source["relayer_identity"],
+                  source["address"], seed_hex, oracle["rpc_url"], expiration_window_ledgers,
+                  max_staleness_secs, decimals, nonces, asset_name, asset),
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+
+    for t in threads:
+        t.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #389 
Closes #391 
Closes #394 
Closes #395 

SUMMARY
 1. fix: restore dropped function signature in prices.rs — a pub fn line had gone missing (likely a bad merge), which is a hard parse error that
     silently blocked the entire crate from compiling. Fixed so I could actually validate anything.
  2. Canonical cross-chain asset registry (issue 3) — new asset_registry.rs: admin-governed mappings from Stellar assets to (chain, 
     foreign_address, decimals), queryable by asset or by chain+address. Both bridge integrations below resolve foreign asset IDs through it
     instead of duplicating lookup logic.
  3. Axelar GMP integration (issue 1) — axelar_gmp.rs + shared bridge_common.rs: defines a canonical 68-byte price-update wire format, trusts only
     the admin-configured Gateway address (mirroring the real "AxelarExecutable" onlyGateway pattern), replay-protects on command_id, and
     attributes each trusted GMP sender to a registered oracle source. Along the way I found cross_chain_verify.rs (#226) existed with working
     code but was never wired into lib.rs at all — fixed that too since this feature extends it.
  4. LayerZero integration (issue 2) — layerzero.rs: lzReceive-style handler with strict per-pathway nonce ordering, trusted-Endpoint
     verification, and the same shared wire format. Bridges into the existing cross-chain verification store so bridged and admin-submitted
     reference prices are compared consistently.
  5. Signed CEX/aggregator adapters (issue 4) — scripts/signed_price_adapter.py: CoinGecko/Binance/Coinbase connectors with provider failover and
     staleness detection, signing each observation via the existing submit_price_with_proof (#216) path. Verified live against all three real 
     APIs, including a genuine staleness-triggered failover and an error-triggered failover.