### PR TITLE
Feature/pruning anomaly volatility reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ node_modules/
 npm-debug.log*
 yarn-error.log
 
+# Python (services/)
+__pycache__/
+*.pyc
+.pytest_cache/
+
 # Environment / secrets
 .env
 .env.*

--- a/contracts/price-oracle/src/explicit_history_pruning_tests.rs
+++ b/contracts/price-oracle/src/explicit_history_pruning_tests.rs
@@ -1,0 +1,149 @@
+#![cfg(test)]
+
+//! Tests for explicit operator-triggered history pruning (`prune_history`).
+//!
+//! `prune_history(asset, target_entries)` lets an admin proactively prune the
+//! oldest history entries for an asset down to a target count, independent of
+//! the automatic pruning that runs during aggregation.
+
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env,
+};
+
+use crate::test_helpers::*;
+use crate::PriceOracleContractClient;
+
+/// Returns the number of contract events emitted in the most recent invocation.
+fn event_count(e: &Env) -> usize {
+    e.events().all().events().len()
+}
+
+/// Submits `count` prices for `asset` from `source`, one per distinct ledger,
+/// starting at sequence 1.
+fn seed_history(
+    e: &Env,
+    client: &PriceOracleContractClient<'_>,
+    source: &Address,
+    asset: &Address,
+    count: u32,
+) {
+    for i in 0..count {
+        ledger_default(e, i + 1, 1000 + (i as u64) * 100);
+        submit_test_price_n(client, source, asset, 100_000 + i as i128, 1000 + (i as u64) * 100, (i + 1) as u64);
+    }
+}
+
+#[test]
+fn test_prune_history_reduces_to_target_and_returns_count() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, _admin, source, asset) = setup_basic(&e);
+
+    seed_history(&e, &client, &source, &asset, 5);
+
+    let (entries_before, _) = client.get_historical_prices_paginated(&asset, &0u32, &50u32);
+    assert_eq!(entries_before.len(), 5);
+
+    let pruned = client.prune_history(&asset, &2u32);
+    assert_eq!(pruned, 3);
+
+    let (entries_after, _) = client.get_historical_prices_paginated(&asset, &0u32, &50u32);
+    assert_eq!(entries_after.len(), 2);
+
+    // The two remaining entries must be the two most recent (highest ledger/price).
+    assert_eq!(entries_after.get_unchecked(0).price, 100_003);
+    assert_eq!(entries_after.get_unchecked(1).price, 100_004);
+}
+
+#[test]
+fn test_prune_history_emits_one_event_per_pruned_entry() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, _admin, source, asset) = setup_basic(&e);
+
+    seed_history(&e, &client, &source, &asset, 4);
+
+    let pruned = client.prune_history(&asset, &1u32);
+    assert_eq!(pruned, 3);
+    assert_eq!(event_count(&e), 3, "one HistoryPrunedEvent per pruned entry");
+}
+
+#[test]
+fn test_prune_history_noop_when_target_at_or_above_count() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, _admin, source, asset) = setup_basic(&e);
+
+    seed_history(&e, &client, &source, &asset, 3);
+
+    // Target equal to current count: no-op.
+    let pruned = client.prune_history(&asset, &3u32);
+    assert_eq!(pruned, 0);
+
+    // Target above current count: still a no-op.
+    let pruned = client.prune_history(&asset, &10u32);
+    assert_eq!(pruned, 0);
+
+    let (entries, _) = client.get_historical_prices_paginated(&asset, &0u32, &50u32);
+    assert_eq!(entries.len(), 3);
+}
+
+#[test]
+fn test_prune_history_down_to_zero() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, _admin, source, asset) = setup_basic(&e);
+
+    seed_history(&e, &client, &source, &asset, 4);
+
+    let pruned = client.prune_history(&asset, &0u32);
+    assert_eq!(pruned, 4);
+
+    let (entries, _) = client.get_historical_prices_paginated(&asset, &0u32, &50u32);
+    assert_eq!(entries.len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #0)")]
+fn test_prune_history_requires_admin() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, _admin, source, asset) = setup_basic(&e);
+
+    seed_history(&e, &client, &source, &asset, 3);
+
+    clear_auth(&e);
+    client.prune_history(&asset, &1u32);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_prune_history_unregistered_asset() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, _admin) = setup_contract(&e);
+    let unregistered = Address::generate(&e);
+
+    client.prune_history(&unregistered, &1u32);
+}
+
+#[test]
+fn test_prune_history_is_separate_from_auto_pruning() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, _admin, source, asset) = setup_basic(&e);
+
+    // setup_basic configures max_history_length = 10, well above this seed
+    // count, so auto-pruning never kicks in here — only the explicit call
+    // below removes entries.
+    seed_history(&e, &client, &source, &asset, 6);
+    let (entries, _) = client.get_historical_prices_paginated(&asset, &0u32, &50u32);
+    assert_eq!(entries.len(), 6, "auto-pruning must not have triggered");
+
+    let pruned = client.prune_history(&asset, &4u32);
+    assert_eq!(pruned, 2);
+
+    let (entries, _) = client.get_historical_prices_paginated(&asset, &0u32, &50u32);
+    assert_eq!(entries.len(), 4);
+}

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -40,6 +40,7 @@ mod optimistic;
 mod pause;
 mod per_asset_decimals;
 mod prices;
+mod pruning;
 mod rate_limiting;
 mod rbac;
 mod recovery;
@@ -65,12 +66,7 @@ mod types;
 mod vdf_sampler;
 mod whitelisting;
 mod zk_verify;
-mod audit_log;
-mod rbac;
 mod emergency_pause;
-mod freeze;
-mod notifications;
-mod config_history;
 mod batch_storage;
 mod price_proof;
 mod price_callback;
@@ -2358,6 +2354,28 @@ impl PriceOracleContract {
     /// Returns the most recent compaction metadata for an asset, if any.
     pub fn get_compaction_metadata(env: Env, asset: Address) -> Option<CompactionMetadata> {
         history::get_compaction_metadata(&env, asset)
+    }
+
+    /// Explicitly prunes the oldest history entries for `asset` down to
+    /// `target_entries`, separate from the automatic pruning that runs on
+    /// aggregation. Lets an operator proactively free storage before hitting
+    /// configured limits. Emits a
+    /// [`HistoryPrunedEvent`](crate::events::HistoryPrunedEvent) per removed
+    /// entry. Admin-only.
+    ///
+    /// # Returns
+    ///
+    /// Number of entries pruned.
+    ///
+    /// # Errors
+    ///
+    /// * [`ErrorCode::NotAuthorized`] — caller is not the admin.
+    /// * [`ErrorCode::AssetNotRegistered`] — asset is not registered.
+    pub fn prune_history(env: Env, asset: Address, target_entries: u32) -> u32 {
+        enter_reentrancy_guard(&env);
+        let result = pruning::prune_history(&env, asset, target_entries);
+        exit_reentrancy_guard(&env);
+        result
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -4814,3 +4832,6 @@ mod issue_309_rate_limiting_tests;
 
 #[cfg(test)]
 mod issue_310_fee_market_tests;
+
+#[cfg(test)]
+mod explicit_history_pruning_tests;

--- a/contracts/price-oracle/src/prices.rs
+++ b/contracts/price-oracle/src/prices.rs
@@ -28,8 +28,6 @@ use crate::types::{
 };
 // Issue #290 — record submission against schedule (liveness check)
 use crate::scheduling;
-// Issue #288 — combined timestamp + ledger-count pruning
-use crate::pruning;
 
 fn build_candidate_aggregate(
     env: &Env,
@@ -1290,7 +1288,7 @@ pub fn get_aggregate_with_version(
     crate::types::VersionedAggregatePrice { aggregate, version }
 }
 
-
+pub fn get_price_with_confidence(env: &Env, asset: Address) -> Option<(AggregatePrice, u32)> {
     let aggregate = get_price(env, asset.clone(), 0)?;
 
     let mut prices: Vec<i128> = Vec::new(env);

--- a/contracts/price-oracle/src/pruning.rs
+++ b/contracts/price-oracle/src/pruning.rs
@@ -21,11 +21,14 @@
 //! - [`get_asset_retention_window`] — query the configured window.
 //! - [`prune_by_timestamp`] — prune stale history entries for an asset.
 //! - [`prune_combined`] — apply both ledger-count and timestamp pruning.
+//! - [`prune_history`] — admin: explicitly prune the oldest entries for an asset
+//!   down to a target entry count, separate from auto-pruning on aggregation.
 
 use soroban_sdk::{panic_with_error, Address, Env};
 
 use crate::admin::get_max_history_length;
 use crate::events::{emit_history_pruned_by_timestamp, HistoryPrunedEvent};
+use crate::history::remove_history_shard_entry;
 use crate::storage::{check_registered_asset, get_admin, LEDGER_BUMP, LEDGER_THRESHOLD};
 use crate::types::{DataKey, ErrorCode, PriceHistoryEntry};
 
@@ -238,4 +241,73 @@ pub fn remove_asset_retention_window(env: &Env, asset: Address) {
         panic_with_error!(env, ErrorCode::NoData);
     }
     env.storage().persistent().remove(&key);
+}
+
+// ─── Explicit operator-triggered pruning ───────────────────────────────────
+
+/// Explicitly prunes the **oldest** history entries for `asset` down to
+/// `target_entries`, removing entries one at a time from both the ledger
+/// index and their underlying storage (per-ledger temporary storage and any
+/// weekly shard bucket).
+///
+/// This is distinct from the automatic pruning applied during aggregation
+/// (which enforces `max_history_length`/`max_history_per_asset`): it lets an
+/// operator proactively reclaim storage for an asset on demand, regardless
+/// of the currently configured limits.
+///
+/// Admin-only. A `target_entries` at or above the current entry count is a
+/// no-op and returns `0`.
+///
+/// # Arguments
+///
+/// * `env` — The Soroban execution environment.
+/// * `asset` — Asset whose history should be pruned.
+/// * `target_entries` — Desired number of history entries to retain after
+///   pruning. Entries beyond this count (oldest first) are removed.
+///
+/// # Returns
+///
+/// Number of entries that were pruned.
+///
+/// # Errors
+///
+/// * [`ErrorCode::NotAuthorized`] — if the caller is not the current admin.
+/// * [`ErrorCode::AssetNotRegistered`] — if the asset is not registered.
+pub fn prune_history(env: &Env, asset: Address, target_entries: u32) -> u32 {
+    let admin = get_admin(env);
+    admin.require_auth();
+    check_registered_asset(env, &asset);
+
+    let ledgers_key = DataKey::PriceHistoryLedgers(asset.clone());
+    let mut ledger_list: soroban_sdk::Vec<u32> = env
+        .storage()
+        .persistent()
+        .get(&ledgers_key)
+        .unwrap_or(soroban_sdk::Vec::new(env));
+
+    let mut pruned_count: u32 = 0;
+    while ledger_list.len() > target_entries {
+        let oldest_ledger = ledger_list.get_unchecked(0);
+        ledger_list.remove(0);
+        env.storage()
+            .temporary()
+            .remove(&DataKey::PriceHistory(asset.clone(), oldest_ledger));
+        remove_history_shard_entry(env, &asset, oldest_ledger);
+        pruned_count += 1;
+        HistoryPrunedEvent {
+            asset: asset.clone(),
+            pruned_ledger: oldest_ledger,
+            remaining: ledger_list.len(),
+        }
+        .publish(env);
+    }
+
+    if pruned_count > 0 {
+        env.storage().persistent().set(&ledgers_key, &ledger_list);
+        env.storage()
+            .persistent()
+            .extend_ttl(&ledgers_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+    }
+
+    pruned_count
 }

--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -1,0 +1,102 @@
+# Off-Chain Anomaly Detection Service
+
+Flags anomalous source submissions **before** they can affect on-chain aggregation. The
+on-chain median in `contracts/price-oracle/src/prices.rs` already resists outliers
+structurally, but this service runs earlier — as submissions stream in — and gives
+operators source + deviation context to act on a misbehaving source faster than waiting
+for it to show up in aggregate data.
+
+Code: `services/anomaly_detection/` (`detector.py` — detection logic, `server.py` — CLI +
+HTTP metrics/alerts endpoint). Shared event-reading code lives in `services/common/`.
+
+## Architecture
+
+```
+oracle_events (Postgres/ClickHouse, see docs/event-streaming/)
+        │  PriceSubmittedEvent rows, per docs/event-streaming/README.md envelope
+        ▼
+StreamingDetector.run()  ──buffers submissions per (asset, ledger) round──▶ score_round()
+        │                                                                        │
+        │                                                              MAD-based modified
+        │                                                              z-score per source
+        ▼                                                                        │
+   AlertSink(s)  ◀───────────────────────────────────────────────────────────────┘
+   (log / webhook / in-memory for the HTTP API)
+```
+
+## Detection method
+
+For every round (all sources' submissions for one asset at one ledger), the service computes
+a **modified z-score** using the median absolute deviation (MAD) — Iglewicz & Hoaglin's
+robust outlier test:
+
+```
+z_i = (price_i − median) / (1.4826 × MAD)
+```
+
+MAD-based scoring is used instead of a mean/stdev z-score because it is itself robust to the
+outliers it's trying to detect (a single wildly wrong submission can't drag the median or MAD
+far, the way it would a mean/stdev).
+
+A submission is flagged when **both**:
+
+- `|z_i| >= mad_threshold` (default `3.5`, the standard Iglewicz–Hoaglin threshold), and
+- `|deviation_bps| >= min_deviation_bps` (default `50` bps).
+
+The second gate exists because MAD can collapse toward zero when peers happen to cluster very
+tightly in a given round; without a floor, ordinary sub-basis-point rounding noise can produce
+enormous but economically meaningless z-scores. Rounds with fewer than `min_peers` (default
+`3`) submissions are skipped — there isn't enough peer data to judge one submission against.
+
+### Optional secondary detector: Isolation Forest
+
+`isolation_forest_outliers()` runs scikit-learn's Isolation Forest over a single source's own
+recent price history to catch temporal anomalies a cross-sectional check can miss. It's fully
+optional — `pip install scikit-learn` to enable it; without it, the function returns `None`
+and the service runs unaffected using MAD detection alone.
+
+## Running
+
+```bash
+pip install -r services/anomaly_detection/requirements.txt
+
+# Seeded-anomaly demo — generates synthetic submissions with known injected
+# outliers and prints every alert found (this is what CI/reviewers can run
+# to confirm the service works end-to-end):
+python -m services.anomaly_detection.server --demo
+
+# Replay an exported JSONL of the oracle_events envelope (see
+# docs/event-streaming/README.md):
+python -m services.anomaly_detection.server --events-file events.jsonl
+
+# Stream continuously from the Postgres event-streaming sink, alerting to a webhook:
+python -m services.anomaly_detection.server \
+  --postgres-dsn postgresql://user:pass@host/db \
+  --webhook-url https://alerts.example.com/oracle-anomalies
+```
+
+## HTTP endpoints
+
+The service listens on `--port` (default `9101`):
+
+| Path | Description |
+|------|-------------|
+| `/health` | Liveness check |
+| `/metrics` | Prometheus-format counters: `oracle_anomaly_alerts_total`, `oracle_anomaly_rounds_scored_total` |
+| `/alerts` | JSON array of the most recent alerts (source, asset, price, z-score, deviation, ledger) |
+
+## Integrating with the existing monitoring stack
+
+Add `/metrics` as another Prometheus scrape target alongside
+`scripts/price-submission-bot.py`'s health server (see `docs/monitoring/README.md`), and pair
+it with the `OracleAnomalousSubmission` rule added to `docs/monitoring/alerts.yml`.
+
+## Testing
+
+```bash
+python -m pytest services/anomaly_detection/tests/
+```
+
+Tests cover: the MAD scoring math on synthetic rounds, that a batch of seeded anomalies is
+found with no false positives on the surrounding clean data, that the streaming detector's
+output matches the batch detector's, and that the final buffered round is flushed correctly.

--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -105,3 +105,16 @@ Consider adding Grafana alerts on:
 - `oracle_errors_total{error_name="InsufficientSources"}` rate > 0 for > 5 min — sources may be offline
 - `oracle_price_submissions_total` rate = 0 for > 15 min per source — source may be down
 - `oracle_latest_price` unchanged for > staleness window — stale price data
+
+## Related off-chain services
+
+These services scrape into the same Prometheus/Grafana stack described above (add their
+`/metrics` endpoints as additional scrape targets):
+
+| Service | Metrics | Docs |
+|---|---|---|
+| Off-chain anomaly detection | `oracle_anomaly_alerts_total`, `oracle_anomaly_rounds_scored_total` | `docs/anomaly-detection.md` |
+| Volatility forecasting | `oracle_volatility_forecasts_total` | `docs/volatility-forecasting.md` |
+| Source reliability scoring | `oracle_reliability_scores_computed_total` | `docs/source-reliability-score.md` |
+
+`docs/monitoring/alerts.yml` includes alerting rules for all three.

--- a/docs/monitoring/alerts.yml
+++ b/docs/monitoring/alerts.yml
@@ -65,3 +65,19 @@ groups:
           severity: critical
         annotations:
           summary: "Oracle contract upgraded — verify wasm hash"
+
+      # Emitted by services/anomaly_detection — see docs/anomaly-detection.md
+      - alert: OracleAnomalousSubmission
+        expr: increase(oracle_anomaly_alerts_total[5m]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "Off-chain anomaly detector flagged a source submission — check /alerts on the detector's metrics endpoint"
+
+      - alert: OracleAnomalyDetectorStalled
+        expr: increase(oracle_anomaly_rounds_scored_total[15m]) == 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Anomaly detector has not scored a new round in over 15m — check its event source"

--- a/docs/monitoring/alerts.yml
+++ b/docs/monitoring/alerts.yml
@@ -81,3 +81,12 @@ groups:
           severity: warning
         annotations:
           summary: "Anomaly detector has not scored a new round in over 15m — check its event source"
+
+      # Emitted by services/volatility_forecast — see docs/volatility-forecasting.md
+      - alert: OracleVolatilityForecastStalled
+        expr: increase(oracle_volatility_forecasts_total[30m]) == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Volatility forecast endpoint has served no forecasts in over 30m"

--- a/docs/monitoring/alerts.yml
+++ b/docs/monitoring/alerts.yml
@@ -90,3 +90,12 @@ groups:
           severity: warning
         annotations:
           summary: "Volatility forecast endpoint has served no forecasts in over 30m"
+
+      # Emitted by services/reliability_score — see docs/source-reliability-score.md
+      - alert: OracleReliabilityScoringStalled
+        expr: increase(oracle_reliability_scores_computed_total[30m]) == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Source reliability scoring has not recomputed scores in over 30m"

--- a/docs/source-reliability-score.md
+++ b/docs/source-reliability-score.md
@@ -1,0 +1,77 @@
+# Off-Chain Source Reliability Score
+
+Publishes a per-source reliability score combining submission **uptime**, **freshness**, and
+**accuracy vs. the aggregate**, computed from indexed events. This is the transparency layer
+underpinning source incentives (the on-chain stake/slash system in
+`contracts/price-oracle/src/reputation.rs`, and the per-round contribution-quality scoring in
+`contracts/price-oracle/src/contribution_quality.rs`) — a transparent score drives better
+source behavior.
+
+Code: `services/reliability_score/` (`scorer.py` — scoring logic, `server.py` — HTTP API +
+dashboard).
+
+## Scoring formula
+
+For each `(asset, source)` pair, over every round the asset was aggregated in:
+
+| Dimension | Weight | Definition |
+|---|---|---|
+| Uptime | 30% | `100 × (rounds the source submitted in / rounds the asset was aggregated in)` |
+| Freshness | 20% | `100 × (1 − lag / max_lag_secs)` averaged over participated rounds, where `lag = round_timestamp − submission_timestamp`, clamped to `[0, 100]` (default `max_lag_secs = 300`) |
+| Accuracy | 50% | `100 × (1 − deviation_bps / max_deviation_bps)` averaged over participated rounds, where `deviation_bps` is the submission's distance from that round's aggregate price, clamped to `[0, 100]` (default `max_deviation_bps = 5000`, i.e. 50%, mirroring `reputation.rs`) |
+
+```
+composite_score = 0.30 × uptime_score + 0.20 × freshness_score + 0.50 × accuracy_score
+```
+
+Weights are configurable via `ScoreWeights` (must sum to `1.0`).
+
+## Reproducibility
+
+`compute_scores(submissions, aggregations)` is a pure function of the indexed event stream: the
+same `PriceSubmittedEvent` / `PriceAggregatedEvent` history always produces the same scores, so
+any operator (or a source disputing its own score) can independently recompute and verify it
+from the same `oracle_events` export. `derive_aggregations()` reconstructs the per-round
+aggregate (median price, `PriceAggregatedEvent`-equivalent) directly from submissions for
+deployments that only index the raw submission stream.
+
+## Running
+
+```bash
+pip install -r services/reliability_score/requirements.txt
+
+# Demo: serves scores for a synthetic source population (one source with
+# scheduled downtime, one with a seeded accuracy problem) — see how the
+# median-based aggregate mutes a single deviant source's own accuracy hit,
+# the same robustness property the on-chain median relies on.
+python -m services.reliability_score.server --demo
+# then open http://localhost:9103/ or:
+curl 'http://localhost:9103/scores?asset=<asset>'
+
+# Against a real exported submission history:
+python -m services.reliability_score.server --events-file events.jsonl
+```
+
+## HTTP endpoints
+
+The service listens on `--port` (default `9103`):
+
+| Path | Description |
+|------|-------------|
+| `/` | Dashboard — lists every source's scores for an asset, sorted by composite score |
+| `/scores?asset=` | JSON array of every source's score for `asset` |
+| `/score?asset=&source=` | JSON score for a single `(asset, source)` — the off-chain equivalent of an on-chain `get_source_score(asset, source)` view; an on-chain view could wrap this once `#[contractimpl]` wiring on the contract is fully restored (see `feat: add explicit prune_history` commit on this branch for the wiring issues found there) |
+| `/metrics` | Prometheus counter: `oracle_reliability_scores_computed_total` |
+| `/health` | Liveness check |
+
+## Testing
+
+```bash
+python -m pytest services/reliability_score/test/
+```
+
+Covers each scoring dimension in isolation (a source with scheduled downtime gets a
+proportionally lower uptime score; a slower submitter scores lower on freshness than a faster
+one at a precisely controlled lag; an inaccurate source scores lower than an accurate one),
+determinism (`compute_scores` on the same input twice returns identical results), and an
+end-to-end HTTP integration test including the `get_source_score`-equivalent endpoint.

--- a/docs/volatility-forecasting.md
+++ b/docs/volatility-forecasting.md
@@ -1,0 +1,71 @@
+# Off-Chain Volatility Forecasting Service
+
+Projects short-term price volatility for an asset from its indexed aggregate price history.
+Consumers and the DAO use the forecast to set risk parameters — deviation thresholds,
+circuit-breaker bounds — ahead of time rather than reactively.
+
+Code: `services/volatility_forecast/` (`forecast.py` — volatility math, `server.py` — HTTP
+forecast endpoint + dashboard).
+
+## Method
+
+Both volatility measures below are computed from the same log-return series of an asset's
+aggregate price history (`PriceAggregatedEvent`, read via the indexed `oracle_events` stream —
+see `docs/event-streaming/README.md`):
+
+- **Realized volatility** — the plain historical stdev of log returns over the full lookback
+  window, annualized. Backward-looking: how volatile the asset has actually been.
+- **Forecast volatility** — an EWMA (RiskMetrics-style, λ=0.94 by default) variance estimate,
+  annualized. Weights recent moves more heavily than old ones, so it reacts to a regime change
+  faster than the flat realized-vol average. The oracle has no options market to derive a true
+  *implied* volatility from; this EWMA projection is the documented stand-in used as the
+  forward-looking forecast basis, the same way an options market's implied vol tends to lead
+  realized vol into a shift.
+
+The **confidence window** projects the forecast volatility over the requested horizon and
+reports a symmetric price band around the last observed price, assuming a lognormal random
+walk (volatility scales with `sqrt(horizon / interval)`, the same assumption behind
+Black-Scholes-style vol scaling). The z-value for an arbitrary confidence level is computed
+via `norm_ppf` (Acklam's rational approximation of the inverse normal CDF) — no `scipy`
+dependency required.
+
+## Running
+
+```bash
+pip install -r services/volatility_forecast/requirements.txt
+
+# Demo: serves the dashboard + forecast endpoint against a synthetic price series.
+python -m services.volatility_forecast.server --demo
+# then open http://localhost:9102/ or:
+curl 'http://localhost:9102/forecast?asset=DEMO&horizon_hours=24&confidence=0.90'
+
+# Against a real exported history:
+python -m services.volatility_forecast.server --events-file events.jsonl --interval-secs 3600
+```
+
+## HTTP endpoints
+
+The service listens on `--port` (default `9102`):
+
+| Path | Description |
+|------|-------------|
+| `/` | Dashboard view — pick an asset, horizon, and confidence level; renders the forecast |
+| `/forecast?asset=&horizon_hours=&confidence=` | JSON forecast: `realized_volatility`, `forecast_volatility`, `lower_bound`, `upper_bound`, `sample_size` |
+| `/metrics` | Prometheus counter: `oracle_volatility_forecasts_total` |
+| `/health` | Liveness check |
+
+Add `/metrics` as a Prometheus scrape target alongside the other oracle off-chain services
+(see `docs/monitoring/README.md`); `docs/monitoring/alerts.yml` includes a staleness rule for
+this service.
+
+## Testing
+
+```bash
+python -m pytest services/volatility_forecast/test/
+```
+
+Covers the volatility math against independently-derived ground truth (a hand-built
+alternating-return series with a known stdev, annualization scaling), the confidence-window
+z-values against textbook normal-quantile values, that the window widens with confidence level
+and horizon as expected, and an end-to-end HTTP integration test against a running server
+instance.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+; Off-chain services under services/ (anomaly detection, volatility
+; forecasting, source reliability scoring) use absolute `services.*`
+; imports; this puts the repo root on sys.path so `pytest` run from the
+; repo root resolves them without installing the package.
+pythonpath = .
+testpaths = services

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Off-chain analysis services for the Stellar Unified Price Oracle."""

--- a/services/anomaly_detection/__init__.py
+++ b/services/anomaly_detection/__init__.py
@@ -1,0 +1,1 @@
+"""Off-chain anomalous-submission detection service."""

--- a/services/anomaly_detection/detector.py
+++ b/services/anomaly_detection/detector.py
@@ -1,0 +1,256 @@
+"""Off-chain statistical anomaly detection for oracle source submissions.
+
+Flags a source's price submission as anomalous *before* it can influence
+on-chain aggregation. The on-chain median already resists outliers
+structurally, but this runs earlier (as submissions stream in) and gives
+operators source + deviation context to act on misbehaving sources faster.
+
+Primary detector: a **modified z-score** (median absolute deviation, MAD)
+computed cross-sectionally across all sources reporting the same asset in
+the same round (Iglewicz & Hoaglin, 1993) — robust to the very outliers it's
+trying to find, unlike a mean/stdev z-score.
+
+Secondary, optional detector: **Isolation Forest** (scikit-learn, if
+installed) run per-source over its own recent price history, to catch
+temporal anomalies (e.g. a single dominant source drifting) that a
+cross-sectional check alone can miss. Entirely optional — the service is
+fully functional without scikit-learn installed.
+"""
+from __future__ import annotations
+
+import logging
+import statistics
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from services.common.events import EventSource, SubmissionEvent, iter_submissions
+
+log = logging.getLogger("anomaly-detector")
+
+# Iglewicz & Hoaglin's recommended modified z-score threshold for outliers.
+DEFAULT_MAD_THRESHOLD = 3.5
+# Minimum peer submissions in a round before a statistical judgement is made;
+# below this, deviation is noise, not signal.
+DEFAULT_MIN_PEERS = 3
+# Minimum absolute deviation from the round median, in basis points, before a
+# high z-score is even considered. At small round sizes the MAD itself can
+# collapse to near zero when peers happen to cluster tightly, which turns
+# ordinary rounding noise into enormous (but economically meaningless)
+# z-scores; gating on a minimum bps move keeps the detector focused on
+# deviations an operator would actually care about.
+DEFAULT_MIN_DEVIATION_BPS = 50.0
+# 1 / Phi^-1(0.75): converts a MAD into a normal-equivalent stdev estimate.
+MAD_SCALE = 1.4826
+
+
+@dataclass
+class AnomalyAlert:
+    """An alert with enough source + deviation context for an operator to act on."""
+
+    asset: str
+    source: str
+    price: int
+    round_median: float
+    modified_z_score: float
+    deviation_bps: float
+    timestamp: int
+    ledger: int
+    reason: str = "mad_outlier"
+
+
+@dataclass
+class DetectorConfig:
+    mad_threshold: float = DEFAULT_MAD_THRESHOLD
+    min_peers: int = DEFAULT_MIN_PEERS
+    min_deviation_bps: float = DEFAULT_MIN_DEVIATION_BPS
+
+
+def score_round(
+    asset: str,
+    ledger: int,
+    submissions: List[SubmissionEvent],
+    config: Optional[DetectorConfig] = None,
+) -> List[AnomalyAlert]:
+    """Scores one round's worth of same-asset, same-ledger submissions.
+
+    A "round" is every source's submission for `asset` at ledger `ledger`.
+    Returns one `AnomalyAlert` per submission whose modified z-score exceeds
+    `config.mad_threshold`.
+    """
+    config = config or DetectorConfig()
+    if len(submissions) < config.min_peers:
+        return []
+
+    prices = [s.price for s in submissions]
+    median = statistics.median(prices)
+    abs_devs = [abs(p - median) for p in prices]
+    mad = statistics.median(abs_devs)
+
+    alerts: List[AnomalyAlert] = []
+    for sub, dev in zip(submissions, abs_devs):
+        if mad == 0:
+            # No spread among peers at all — any deviation is a hard outlier;
+            # the modified z-score is undefined (division by zero) here.
+            z = float("inf") if dev > 0 else 0.0
+        else:
+            z = (sub.price - median) / (MAD_SCALE * mad)
+
+        deviation_bps = ((sub.price - median) / median * 10_000) if median else 0.0
+        if abs(z) >= config.mad_threshold and abs(deviation_bps) >= config.min_deviation_bps:
+            alerts.append(
+                AnomalyAlert(
+                    asset=asset,
+                    source=sub.source,
+                    price=sub.price,
+                    round_median=median,
+                    modified_z_score=z,
+                    deviation_bps=deviation_bps,
+                    timestamp=sub.timestamp,
+                    ledger=ledger,
+                )
+            )
+    return alerts
+
+
+def detect_anomalies(
+    events: Iterable[SubmissionEvent], config: Optional[DetectorConfig] = None
+) -> List[AnomalyAlert]:
+    """Batch entry point: scores every round found in `events`."""
+    config = config or DetectorConfig()
+    rounds: Dict[Tuple[str, int], List[SubmissionEvent]] = defaultdict(list)
+    for event in events:
+        rounds[(event.asset, event.ledger)].append(event)
+
+    alerts: List[AnomalyAlert] = []
+    for (asset, ledger), submissions in rounds.items():
+        alerts.extend(score_round(asset, ledger, submissions, config))
+    alerts.sort(key=lambda a: (a.ledger, a.asset, a.source))
+    return alerts
+
+
+# ─── Alert delivery ─────────────────────────────────────────────────────────
+
+
+class AlertSink:
+    def emit(self, alert: AnomalyAlert) -> None:
+        raise NotImplementedError
+
+
+class LoggingAlertSink(AlertSink):
+    def emit(self, alert: AnomalyAlert) -> None:
+        log.warning(
+            "anomalous submission: asset=%s source=%s price=%s median=%s z=%.2f dev_bps=%.1f ledger=%s",
+            alert.asset,
+            alert.source,
+            alert.price,
+            alert.round_median,
+            alert.modified_z_score,
+            alert.deviation_bps,
+            alert.ledger,
+        )
+
+
+class WebhookAlertSink(AlertSink):
+    """Posts each alert as JSON to a webhook URL (e.g. an alerting gateway).
+
+    Delivery failures are logged, never raised — a flaky webhook must not
+    take down the detection pipeline.
+    """
+
+    def __init__(self, url: str, timeout_secs: float = 5.0):
+        self.url = url
+        self.timeout_secs = timeout_secs
+
+    def emit(self, alert: AnomalyAlert) -> None:
+        import requests
+
+        try:
+            requests.post(self.url, json=asdict(alert), timeout=self.timeout_secs)
+        except requests.RequestException:
+            log.exception("failed to deliver anomaly webhook to %s", self.url)
+
+
+# ─── Streaming pipeline ─────────────────────────────────────────────────────
+
+
+@dataclass
+class StreamingDetector:
+    """Buffers submissions per-asset by ledger round and scores each round as
+    soon as it closes (i.e. once a submission for a later ledger of the same
+    asset arrives), forwarding alerts to `sinks` as they're found.
+
+    This is the "analysis pipeline" consuming a stream of submission events:
+    feed it events in roughly ledger order (as they arrive off an indexer or
+    a JSONL tail) via `feed`, or drain a finite/batch source via `run`.
+    """
+
+    config: DetectorConfig = field(default_factory=DetectorConfig)
+    sinks: List[AlertSink] = field(default_factory=lambda: [LoggingAlertSink()])
+    alerts_emitted: int = 0
+    rounds_scored: int = 0
+    _buffer: Dict[str, Tuple[int, List[SubmissionEvent]]] = field(default_factory=dict)
+
+    def feed(self, event: SubmissionEvent) -> List[AnomalyAlert]:
+        flushed: List[AnomalyAlert] = []
+        bucket = self._buffer.get(event.asset)
+        if bucket is not None and bucket[0] != event.ledger:
+            flushed = self._flush(event.asset, *bucket)
+            bucket = None
+        if bucket is None:
+            self._buffer[event.asset] = (event.ledger, [event])
+        else:
+            bucket[1].append(event)
+        return flushed
+
+    def flush_all(self) -> List[AnomalyAlert]:
+        """Scores every buffered (possibly still-open) round. Call once the
+        underlying stream is exhausted so the final round isn't lost."""
+        alerts: List[AnomalyAlert] = []
+        for asset in list(self._buffer.keys()):
+            ledger, submissions = self._buffer.pop(asset)
+            alerts.extend(self._flush(asset, ledger, submissions))
+        return alerts
+
+    def run(self, source: EventSource) -> List[AnomalyAlert]:
+        alerts: List[AnomalyAlert] = []
+        for event in iter_submissions(source):
+            alerts.extend(self.feed(event))
+        alerts.extend(self.flush_all())
+        return alerts
+
+    def _flush(self, asset: str, ledger: int, submissions: List[SubmissionEvent]) -> List[AnomalyAlert]:
+        alerts = score_round(asset, ledger, submissions, self.config)
+        self.rounds_scored += 1
+        for alert in alerts:
+            self.alerts_emitted += 1
+            for sink in self.sinks:
+                sink.emit(alert)
+        return alerts
+
+
+# ─── Optional secondary detector: Isolation Forest ─────────────────────────
+
+
+def isolation_forest_outliers(
+    price_history: List[float], contamination: float = 0.05
+) -> Optional[List[bool]]:
+    """Flags temporal outliers within a single source's own price history
+    using scikit-learn's Isolation Forest, if it's installed.
+
+    Returns `None` (never raises) when scikit-learn is unavailable — this
+    detector is a purely optional complement to the MAD-based round scoring
+    above, which is what the service relies on by default.
+    """
+    if len(price_history) < 10:
+        return None
+    try:
+        from sklearn.ensemble import IsolationForest
+    except ImportError:
+        log.debug("scikit-learn not installed; skipping isolation-forest pass")
+        return None
+
+    values = [[p] for p in price_history]
+    model = IsolationForest(contamination=contamination, random_state=0)
+    predictions = model.fit_predict(values)
+    return [p == -1 for p in predictions]

--- a/services/anomaly_detection/requirements.txt
+++ b/services/anomaly_detection/requirements.txt
@@ -1,0 +1,6 @@
+# Off-chain anomaly-detection service dependencies
+requests==2.32.3
+
+# Optional extras (the service runs fully without these):
+#   pip install scikit-learn==1.5.2   — enables the isolation-forest secondary detector
+#   pip install psycopg2-binary==2.9.9 — enables streaming from the oracle_events Postgres table

--- a/services/anomaly_detection/server.py
+++ b/services/anomaly_detection/server.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Runs the off-chain anomaly-detection service: streams oracle submission
+events through `StreamingDetector` and serves recent alerts plus Prometheus
+metrics over HTTP, so it plugs into the existing docs/monitoring stack the
+same way scripts/price-submission-bot.py does.
+
+Usage:
+    python -m services.anomaly_detection.server --demo
+    python -m services.anomaly_detection.server --events-file events.jsonl
+    python -m services.anomaly_detection.server --postgres-dsn postgresql://... --webhook-url https://...
+
+See docs/anomaly-detection.md for configuration and integration details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import asdict
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Lock, Thread
+from typing import List, Optional
+
+from services.anomaly_detection.detector import (
+    AlertSink,
+    AnomalyAlert,
+    DEFAULT_MAD_THRESHOLD,
+    DetectorConfig,
+    LoggingAlertSink,
+    StreamingDetector,
+    WebhookAlertSink,
+)
+from services.common.events import iter_from_postgres
+from services.common.events import TOPIC_PRICE_SUBMITTED
+from services.common.synthetic import generate_submissions
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("anomaly-detector.server")
+
+_MAX_RECENT_ALERTS = 500
+_alerts_lock = Lock()
+_recent_alerts: List[AnomalyAlert] = []
+
+
+class RecentAlertsSink(AlertSink):
+    """Keeps the most recent alerts in memory for the `/alerts` endpoint."""
+
+    def emit(self, alert: AnomalyAlert) -> None:
+        with _alerts_lock:
+            _recent_alerts.append(alert)
+            if len(_recent_alerts) > _MAX_RECENT_ALERTS:
+                del _recent_alerts[: len(_recent_alerts) - _MAX_RECENT_ALERTS]
+
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    detector: Optional[StreamingDetector] = None
+
+    def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path == "/metrics":
+            lines = [
+                f"oracle_anomaly_alerts_total {self.detector.alerts_emitted}",
+                f"oracle_anomaly_rounds_scored_total {self.detector.rounds_scored}",
+            ]
+            self._respond(200, "text/plain", ("\n".join(lines) + "\n").encode())
+        elif self.path == "/alerts":
+            with _alerts_lock:
+                payload = [asdict(a) for a in _recent_alerts]
+            self._respond(200, "application/json", json.dumps(payload).encode())
+        elif self.path == "/health":
+            self._respond(200, "application/json", b'{"status": "ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _respond(self, code: int, content_type: str, body: bytes) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):  # silence default request logging
+        pass
+
+
+def run_metrics_server(port: int, detector: StreamingDetector) -> None:
+    MetricsHandler.detector = detector
+    HTTPServer(("0.0.0.0", port), MetricsHandler).serve_forever()
+
+
+def build_sinks(webhook_url: Optional[str]) -> List[AlertSink]:
+    sinks: List[AlertSink] = [LoggingAlertSink(), RecentAlertsSink()]
+    if webhook_url:
+        sinks.append(WebhookAlertSink(webhook_url))
+    return sinks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Oracle off-chain anomaly-detection service")
+    parser.add_argument("--events-file", help="JSONL file of event envelopes to replay")
+    parser.add_argument("--postgres-dsn", help="Postgres DSN to stream events from the oracle_events table")
+    parser.add_argument("--demo", action="store_true", help="run against seeded synthetic anomalies and exit")
+    parser.add_argument("--webhook-url", default=None, help="optional webhook to POST each alert to")
+    parser.add_argument("--port", type=int, default=9101, help="metrics/alerts HTTP port")
+    parser.add_argument("--mad-threshold", type=float, default=DEFAULT_MAD_THRESHOLD)
+    args = parser.parse_args()
+
+    config = DetectorConfig(mad_threshold=args.mad_threshold)
+    detector = StreamingDetector(config=config, sinks=build_sinks(args.webhook_url))
+
+    if args.demo:
+        events = generate_submissions(
+            n_rounds=100,
+            sources=("SOURCE_A", "SOURCE_B", "SOURCE_C", "SOURCE_D"),
+            anomalies={40: {"SOURCE_B": 900.0}, 75: {"SOURCE_D": -1200.0}},
+        )
+        alerts = detector.run(events)
+        log.info("demo run complete: %d alert(s) from %d round(s)", len(alerts), detector.rounds_scored)
+        for alert in alerts:
+            print(json.dumps(asdict(alert)))
+        return
+
+    Thread(target=run_metrics_server, args=(args.port, detector), daemon=True).start()
+    log.info("anomaly detector metrics/alerts endpoint listening on :%d", args.port)
+
+    if args.postgres_dsn:
+        source = iter_from_postgres(args.postgres_dsn, topics={TOPIC_PRICE_SUBMITTED})
+    elif args.events_file:
+        source = args.events_file
+    else:
+        parser.error("one of --events-file, --postgres-dsn, or --demo is required")
+        return
+
+    detector.run(source)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/anomaly_detection/test/test_detector.py
+++ b/services/anomaly_detection/test/test_detector.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from services.anomaly_detection.detector import (
+    DetectorConfig,
+    StreamingDetector,
+    detect_anomalies,
+    isolation_forest_outliers,
+    score_round,
+)
+from services.common.events import iter_submissions
+from services.common.synthetic import generate_submissions
+
+
+def test_score_round_flags_the_seeded_outlier_and_spares_normal_peers():
+    submissions = list(
+        iter_submissions(
+            generate_submissions(
+                n_rounds=1,
+                sources=("A", "B", "C", "D"),
+                noise_bps=5.0,
+                seed=1,
+                anomalies={0: {"C": 1000.0}},  # +10% off from the true price
+            )
+        )
+    )
+    alerts = score_round("asset", 1, submissions, DetectorConfig())
+
+    flagged_sources = {a.source for a in alerts}
+    assert flagged_sources == {"C"}
+    assert alerts[0].deviation_bps > 500  # clearly off from the round median
+
+
+def test_score_round_no_alerts_when_all_sources_agree():
+    submissions = list(
+        iter_submissions(
+            generate_submissions(n_rounds=1, sources=("A", "B", "C"), noise_bps=2.0, seed=2)
+        )
+    )
+    alerts = score_round("asset", 1, submissions, DetectorConfig())
+    assert alerts == []
+
+
+def test_score_round_requires_minimum_peers():
+    submissions = list(
+        iter_submissions(
+            generate_submissions(
+                n_rounds=1, sources=("A", "B"), noise_bps=5.0, seed=3, anomalies={0: {"B": 5000.0}}
+            )
+        )
+    )
+    # Only 2 peers < DEFAULT_MIN_PEERS(3) — too little history to judge, no alert.
+    alerts = score_round("asset", 1, submissions, DetectorConfig(min_peers=3))
+    assert alerts == []
+
+
+def test_detect_anomalies_batch_finds_all_seeded_anomalies_and_nothing_else():
+    events = generate_submissions(
+        n_rounds=200,
+        sources=("SOURCE_A", "SOURCE_B", "SOURCE_C", "SOURCE_D", "SOURCE_E"),
+        noise_bps=10.0,
+        seed=42,
+        anomalies={
+            50: {"SOURCE_B": 800.0},
+            120: {"SOURCE_D": -900.0},
+            150: {"SOURCE_A": 1500.0},
+        },
+    )
+    submissions = list(iter_submissions(events))
+    alerts = detect_anomalies(submissions, DetectorConfig())
+
+    # generate_submissions starts at ledger_start=1, so round_idx r is ledger r+1.
+    seeded = {(51, "SOURCE_B"), (121, "SOURCE_D"), (151, "SOURCE_A")}
+    found = {(a.ledger, a.source) for a in alerts}
+
+    assert seeded.issubset(found), f"missing seeded anomalies: {seeded - found}"
+    # The min-deviation-bps gate keeps the detector from firing on ordinary
+    # Gaussian noise, so clean rounds shouldn't add any false positives here.
+    assert found - seeded == set(), f"unexpected extra alerts: {found - seeded}"
+
+
+def test_streaming_detector_matches_batch_detection():
+    events = generate_submissions(
+        n_rounds=60,
+        sources=("A", "B", "C", "D"),
+        noise_bps=8.0,
+        seed=7,
+        anomalies={10: {"B": 1000.0}, 30: {"D": -1100.0}},
+    )
+    batch_alerts = detect_anomalies(list(iter_submissions(events)), DetectorConfig())
+
+    detector = StreamingDetector(config=DetectorConfig(), sinks=[])
+    streamed_alerts = detector.run(events)
+
+    batch_keys = sorted((a.ledger, a.source) for a in batch_alerts)
+    streamed_keys = sorted((a.ledger, a.source) for a in streamed_alerts)
+    assert batch_keys == streamed_keys
+    assert detector.alerts_emitted == len(streamed_alerts)
+    assert detector.rounds_scored == 60
+
+
+def test_streaming_detector_flushes_the_final_round():
+    # A single round with no follow-up round to trigger a flush via `feed`
+    # alone — `run` must still score it via the trailing `flush_all`.
+    events = generate_submissions(n_rounds=1, sources=("A", "B", "C"), anomalies={0: {"C": 2000.0}})
+    detector = StreamingDetector(sinks=[])
+    alerts = detector.run(events)
+    assert len(alerts) == 1
+    assert alerts[0].source == "C"
+
+
+def test_isolation_forest_outliers_returns_none_without_sklearn_or_short_history():
+    # With fewer than 10 points the function short-circuits regardless of
+    # whether scikit-learn is installed, keeping this test dependency-free.
+    assert isolation_forest_outliers([1.0, 2.0, 3.0]) is None

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared building blocks for the oracle's off-chain analysis services."""

--- a/services/common/events.py
+++ b/services/common/events.py
@@ -1,0 +1,150 @@
+"""Reads the canonical oracle event envelope described in
+docs/event-streaming/README.md:
+
+    {"ledger": 12345, "timestamp": 67890, "contract_id": "C...",
+     "topic": "price_submitted", "data": {...}}
+
+Shared by the anomaly-detection, volatility-forecast, and reliability-score
+services so each pipeline consumes the same indexed event stream (a JSONL
+export of the `oracle_events` table, or the table itself via Postgres).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional, Union
+
+# Topics emitted by contracts/price-oracle/src/events.rs that these services
+# care about (see PriceSubmittedEvent / PriceAggregatedEvent).
+TOPIC_PRICE_SUBMITTED = "price_submitted"
+TOPIC_PRICE_AGGREGATED = "price_aggregated"
+
+EventSource = Union[str, Path, Iterable[dict]]
+
+
+@dataclass(frozen=True)
+class EventEnvelope:
+    ledger: int
+    timestamp: int
+    contract_id: str
+    topic: str
+    data: dict
+
+    @staticmethod
+    def from_dict(row: dict) -> "EventEnvelope":
+        return EventEnvelope(
+            ledger=int(row["ledger"]),
+            timestamp=int(row["timestamp"]),
+            contract_id=str(row["contract_id"]),
+            topic=str(row["topic"]),
+            data=dict(row["data"]),
+        )
+
+
+@dataclass(frozen=True)
+class SubmissionEvent:
+    """A single source's raw price submission (`PriceSubmittedEvent`)."""
+
+    ledger: int
+    timestamp: int
+    contract_id: str
+    asset: str
+    source: str
+    price: int
+
+
+@dataclass(frozen=True)
+class AggregationEvent:
+    """A newly computed aggregate price (`PriceAggregatedEvent`)."""
+
+    ledger: int
+    timestamp: int
+    contract_id: str
+    asset: str
+    price: int
+    num_sources: int
+
+
+def _iter_raw(source: EventSource) -> Iterator[dict]:
+    """Yields raw envelope dicts from a JSONL file path or an in-memory iterable."""
+    if isinstance(source, (str, Path)):
+        with open(source, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    yield json.loads(line)
+    else:
+        for row in source:
+            yield row
+
+
+def iter_envelopes(source: EventSource, topics: Optional[set] = None) -> Iterator[EventEnvelope]:
+    for row in _iter_raw(source):
+        env = EventEnvelope.from_dict(row)
+        if topics is None or env.topic in topics:
+            yield env
+
+
+def iter_submissions(source: EventSource) -> Iterator[SubmissionEvent]:
+    for env in iter_envelopes(source, topics={TOPIC_PRICE_SUBMITTED}):
+        yield SubmissionEvent(
+            ledger=env.ledger,
+            timestamp=env.timestamp,
+            contract_id=env.contract_id,
+            asset=str(env.data["asset"]),
+            source=str(env.data["source"]),
+            price=int(env.data["price"]),
+        )
+
+
+def iter_aggregations(source: EventSource) -> Iterator[AggregationEvent]:
+    for env in iter_envelopes(source, topics={TOPIC_PRICE_AGGREGATED}):
+        yield AggregationEvent(
+            ledger=env.ledger,
+            timestamp=env.timestamp,
+            contract_id=env.contract_id,
+            asset=str(env.data["asset"]),
+            price=int(env.data["price"]),
+            num_sources=int(env.data.get("num_sources", 0)),
+        )
+
+
+def iter_from_postgres(
+    dsn: str,
+    topics: Optional[set] = None,
+    since_id: int = 0,
+    batch_size: int = 1000,
+) -> Iterator[dict]:
+    """Streams raw envelope rows from the `oracle_events` table (see
+    docs/event-streaming/postgresql_schema.sql), ordered by `id`.
+
+    Requires `psycopg2` (or `psycopg2-binary`); imported lazily so the rest of
+    this module has no hard dependency on it.
+    """
+    import psycopg2
+    import psycopg2.extras
+
+    where = "id > %s"
+    if topics:
+        where += " AND topic = ANY(%s)"
+    query = (
+        f"SELECT id, ledger, timestamp, contract_id, topic, data "
+        f"FROM oracle_events WHERE {where} ORDER BY id ASC LIMIT %s"
+    )
+
+    with psycopg2.connect(dsn) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cursor_id = since_id
+            while True:
+                params: list[Any] = [cursor_id]
+                if topics:
+                    params.append(list(topics))
+                params.append(batch_size)
+                cur.execute(query, params)
+                rows = cur.fetchall()
+                if not rows:
+                    return
+                for row in rows:
+                    cursor_id = row["id"]
+                    yield dict(row)

--- a/services/common/synthetic.py
+++ b/services/common/synthetic.py
@@ -1,0 +1,82 @@
+"""Synthetic submission-event generation, shared by the demo entrypoints and
+test suites of the anomaly-detection, volatility-forecast, and
+reliability-score services.
+
+Produces canonical event envelopes (see `services.common.events`) so the
+generated data can be fed through the exact same code path as a real
+indexed event stream.
+"""
+from __future__ import annotations
+
+import random
+from typing import Dict, Iterable, List, Optional, Set
+
+from services.common.events import TOPIC_PRICE_SUBMITTED
+
+DEFAULT_CONTRACT_ID = "CDEMOCONTRACTIDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+
+def generate_submissions(
+    asset: str = "CDEMOASSETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    sources: Iterable[str] = ("SOURCE_A", "SOURCE_B", "SOURCE_C"),
+    n_rounds: int = 200,
+    base_price: int = 100_000_000,
+    start_ts: int = 1_700_000_000,
+    interval_secs: int = 60,
+    noise_bps: float = 15.0,
+    drift_bps_per_round: float = 0.0,
+    seed: int = 1234,
+    anomalies: Optional[Dict[int, Dict[str, float]]] = None,
+    missing: Optional[Dict[str, Set[int]]] = None,
+    contract_id: str = DEFAULT_CONTRACT_ID,
+    ledger_start: int = 1,
+) -> List[dict]:
+    """Generates `n_rounds` of per-source submissions for a single asset.
+
+    * `noise_bps` — stdev of normal per-source noise around the "true" price,
+      in basis points.
+    * `drift_bps_per_round` — slow deterministic drift applied to the true
+      price each round, to give volatility/forecast tests a realistic trend.
+    * `anomalies` — `{round_idx: {source: deviation_bps}}`. The named source's
+      submission in that round is shifted by `deviation_bps` (signed) on top
+      of its normal noise — this is the "seeded anomaly" consumed by the
+      anomaly-detection tests.
+    * `missing` — `{source: {round_idx, ...}}`. The named source submits
+      nothing in those rounds, simulating downtime for uptime scoring.
+    """
+    rng = random.Random(seed)
+    sources = list(sources)
+    anomalies = anomalies or {}
+    missing = missing or {}
+
+    events: List[dict] = []
+    true_price = float(base_price)
+    ledger = ledger_start
+
+    for round_idx in range(n_rounds):
+        ts = start_ts + round_idx * interval_secs
+        true_price *= 1.0 + (drift_bps_per_round / 10_000.0)
+
+        for source in sources:
+            if round_idx in missing.get(source, ()):
+                continue
+
+            noise = rng.gauss(0.0, noise_bps) / 10_000.0
+            price = true_price * (1.0 + noise)
+
+            deviation_bps = anomalies.get(round_idx, {}).get(source)
+            if deviation_bps is not None:
+                price = true_price * (1.0 + deviation_bps / 10_000.0)
+
+            events.append(
+                {
+                    "ledger": ledger,
+                    "timestamp": ts,
+                    "contract_id": contract_id,
+                    "topic": TOPIC_PRICE_SUBMITTED,
+                    "data": {"asset": asset, "source": source, "price": int(round(price))},
+                }
+            )
+        ledger += 1
+
+    return events

--- a/services/common/synthetic.py
+++ b/services/common/synthetic.py
@@ -8,10 +8,11 @@ indexed event stream.
 """
 from __future__ import annotations
 
+import math
 import random
 from typing import Dict, Iterable, List, Optional, Set
 
-from services.common.events import TOPIC_PRICE_SUBMITTED
+from services.common.events import TOPIC_PRICE_AGGREGATED, TOPIC_PRICE_SUBMITTED
 
 DEFAULT_CONTRACT_ID = "CDEMOCONTRACTIDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
@@ -78,5 +79,45 @@ def generate_submissions(
                 }
             )
         ledger += 1
+
+    return events
+
+
+def generate_price_series(
+    asset: str = "CDEMOASSETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    n_points: int = 200,
+    start_price: float = 100_000_000.0,
+    interval_secs: int = 3600,
+    start_ts: int = 1_700_000_000,
+    period_volatility: float = 0.01,
+    drift_per_period: float = 0.0,
+    seed: int = 1234,
+    contract_id: str = DEFAULT_CONTRACT_ID,
+    ledger_start: int = 1,
+) -> List[dict]:
+    """Generates a geometric-Brownian-motion aggregate price series as
+    `price_aggregated` event envelopes, for volatility-forecast and
+    reliability-score tests/demos.
+
+    `period_volatility` is the per-period (per `interval_secs`) log-return
+    stdev — e.g. `0.01` means roughly 1% typical move between points.
+    """
+    rng = random.Random(seed)
+    price = start_price
+    events: List[dict] = []
+
+    for i in range(n_points):
+        if i > 0:
+            shock = rng.gauss(drift_per_period, period_volatility)
+            price *= math.exp(shock)
+        events.append(
+            {
+                "ledger": ledger_start + i,
+                "timestamp": start_ts + i * interval_secs,
+                "contract_id": contract_id,
+                "topic": TOPIC_PRICE_AGGREGATED,
+                "data": {"asset": asset, "price": int(round(price)), "num_sources": 3},
+            }
+        )
 
     return events

--- a/services/reliability_score/__init__.py
+++ b/services/reliability_score/__init__.py
@@ -1,0 +1,1 @@
+"""Off-chain per-source reliability scoring service."""

--- a/services/reliability_score/requirements.txt
+++ b/services/reliability_score/requirements.txt
@@ -1,0 +1,5 @@
+# Off-chain source-reliability-scoring service dependencies.
+# Pure standard library — no hard runtime dependencies.
+
+# Optional extra (enables streaming from the oracle_events Postgres table):
+#   pip install psycopg2-binary==2.9.9

--- a/services/reliability_score/scorer.py
+++ b/services/reliability_score/scorer.py
@@ -1,0 +1,185 @@
+"""Computes a per-source reliability score from indexed oracle events,
+combining submission uptime, freshness, and accuracy vs. the aggregate —
+the transparency mechanism underpinning source incentives (see the
+on-chain stake/reputation system in contracts/price-oracle/src/reputation.rs).
+
+The score is a pure function of the indexed `PriceSubmittedEvent` /
+`PriceAggregatedEvent` stream: given the same events, `compute_scores`
+always returns the same scores — "reproducible" in the sense the issue
+asks for, and independently auditable by anyone re-running it against the
+same indexed history.
+"""
+from __future__ import annotations
+
+import statistics
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+from services.common.events import AggregationEvent, SubmissionEvent
+
+DEFAULT_UPTIME_WEIGHT = 0.30
+DEFAULT_FRESHNESS_WEIGHT = 0.20
+DEFAULT_ACCURACY_WEIGHT = 0.50
+
+# A submission arriving this many seconds (or more) after the round's
+# aggregation timestamp scores 0 on freshness; 0 lag scores 100, linear
+# between.
+DEFAULT_MAX_LAG_SECS = 300.0
+# A submission deviating this many basis points (or more) from the round's
+# aggregate price scores 0 on accuracy; mirrors the 50% cliff used by the
+# on-chain reputation system in reputation.rs.
+DEFAULT_MAX_DEVIATION_BPS = 5_000.0
+
+
+@dataclass(frozen=True)
+class ScoreWeights:
+    uptime: float = DEFAULT_UPTIME_WEIGHT
+    freshness: float = DEFAULT_FRESHNESS_WEIGHT
+    accuracy: float = DEFAULT_ACCURACY_WEIGHT
+
+    def __post_init__(self):
+        total = self.uptime + self.freshness + self.accuracy
+        if not 0.999 <= total <= 1.001:
+            raise ValueError(f"weights must sum to 1.0, got {total}")
+
+
+@dataclass(frozen=True)
+class SourceReliabilityScore:
+    asset: str
+    source: str
+    uptime_score: float
+    freshness_score: float
+    accuracy_score: float
+    composite_score: float
+    rounds_expected: int
+    rounds_participated: int
+
+
+def derive_aggregations(submissions: Iterable[SubmissionEvent]) -> List[AggregationEvent]:
+    """Derives one `AggregationEvent` per (asset, ledger) round as the
+    median of that round's submissions, for deployments that index raw
+    submissions but not a separate aggregation event stream.
+
+    Mirrors the on-chain aggregate: price is the round's median, timestamp
+    is the most recent contributing submission's timestamp (see
+    `PriceAggregatedEvent` in contracts/price-oracle/src/events.rs).
+    """
+    rounds: Dict[Tuple[str, int], List[SubmissionEvent]] = defaultdict(list)
+    for sub in submissions:
+        rounds[(sub.asset, sub.ledger)].append(sub)
+
+    aggregations: List[AggregationEvent] = []
+    for (asset, ledger), subs in rounds.items():
+        prices = sorted(s.price for s in subs)
+        median_price = statistics.median(prices)
+        latest_ts = max(s.timestamp for s in subs)
+        aggregations.append(
+            AggregationEvent(
+                ledger=ledger,
+                timestamp=latest_ts,
+                contract_id=subs[0].contract_id,
+                asset=asset,
+                price=int(median_price),
+                num_sources=len(subs),
+            )
+        )
+    return aggregations
+
+
+def compute_scores(
+    submissions: Iterable[SubmissionEvent],
+    aggregations: Iterable[AggregationEvent],
+    weights: ScoreWeights = ScoreWeights(),
+    max_lag_secs: float = DEFAULT_MAX_LAG_SECS,
+    max_deviation_bps: float = DEFAULT_MAX_DEVIATION_BPS,
+) -> List[SourceReliabilityScore]:
+    """Computes one `SourceReliabilityScore` per (asset, source) pair seen
+    in `submissions`.
+
+    * **Uptime** — the fraction of the asset's aggregated rounds the source
+      actually submitted a price for.
+    * **Freshness** — how promptly (relative to `max_lag_secs`) the source's
+      submissions arrived ahead of/around the round's aggregation.
+    * **Accuracy** — how close (relative to `max_deviation_bps`) the
+      source's submitted prices were to each round's aggregate price.
+
+    All three sub-scores and the weighted composite are in `[0, 100]`.
+    """
+    aggs_by_round: Dict[Tuple[str, int], AggregationEvent] = {}
+    rounds_by_asset: Dict[str, Set[int]] = defaultdict(set)
+    for agg in aggregations:
+        aggs_by_round[(agg.asset, agg.ledger)] = agg
+        rounds_by_asset[agg.asset].add(agg.ledger)
+
+    subs_by_round_source: Dict[Tuple[str, int, str], SubmissionEvent] = {}
+    sources_by_asset: Dict[str, Set[str]] = defaultdict(set)
+    for sub in submissions:
+        subs_by_round_source[(sub.asset, sub.ledger, sub.source)] = sub
+        sources_by_asset[sub.asset].add(sub.source)
+
+    scores: List[SourceReliabilityScore] = []
+    for asset, expected_ledgers in rounds_by_asset.items():
+        expected_ledgers_sorted = sorted(expected_ledgers)
+        n_expected = len(expected_ledgers_sorted)
+        if n_expected == 0:
+            continue
+
+        for source in sorted(sources_by_asset.get(asset, ())):
+            participated = 0
+            lag_scores: List[float] = []
+            accuracy_scores: List[float] = []
+
+            for ledger in expected_ledgers_sorted:
+                sub = subs_by_round_source.get((asset, ledger, source))
+                if sub is None:
+                    continue
+                participated += 1
+                agg = aggs_by_round[(asset, ledger)]
+
+                lag = max(0.0, agg.timestamp - sub.timestamp)
+                lag_score = 100.0 if max_lag_secs <= 0 else max(0.0, 100.0 * (1.0 - lag / max_lag_secs))
+                lag_scores.append(lag_score)
+
+                if agg.price != 0:
+                    deviation_bps = abs(sub.price - agg.price) / abs(agg.price) * 10_000
+                else:
+                    deviation_bps = 0.0 if sub.price == agg.price else max_deviation_bps
+                accuracy_score = max(0.0, 100.0 * (1.0 - deviation_bps / max_deviation_bps))
+                accuracy_scores.append(accuracy_score)
+
+            uptime_score = 100.0 * participated / n_expected
+            freshness_score = statistics.mean(lag_scores) if lag_scores else 0.0
+            accuracy_score = statistics.mean(accuracy_scores) if accuracy_scores else 0.0
+            composite = (
+                weights.uptime * uptime_score
+                + weights.freshness * freshness_score
+                + weights.accuracy * accuracy_score
+            )
+
+            scores.append(
+                SourceReliabilityScore(
+                    asset=asset,
+                    source=source,
+                    uptime_score=uptime_score,
+                    freshness_score=freshness_score,
+                    accuracy_score=accuracy_score,
+                    composite_score=composite,
+                    rounds_expected=n_expected,
+                    rounds_participated=participated,
+                )
+            )
+
+    return scores
+
+
+def get_source_score(
+    scores: Iterable[SourceReliabilityScore], asset: str, source: str
+) -> Optional[SourceReliabilityScore]:
+    """Looks up a single (asset, source) score from a previously-computed
+    `compute_scores` result — the off-chain equivalent of an on-chain
+    `get_source_score(asset, source)` view (see docs/source-reliability-score.md)."""
+    for score in scores:
+        if score.asset == asset and score.source == source:
+            return score
+    return None

--- a/services/reliability_score/server.py
+++ b/services/reliability_score/server.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Runs the source-reliability-scoring service: computes per-source
+reliability scores from indexed events and serves them over HTTP, plus a
+dashboard view. See docs/source-reliability-score.md.
+
+Usage:
+    python -m services.reliability_score.server --demo
+    python -m services.reliability_score.server --events-file events.jsonl --port 9103
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import asdict
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import List, Optional
+from urllib.parse import parse_qs, urlparse
+
+from services.common.events import TOPIC_PRICE_SUBMITTED, iter_from_postgres, iter_submissions
+from services.common.synthetic import generate_submissions
+from services.reliability_score.scorer import (
+    ScoreWeights,
+    SourceReliabilityScore,
+    compute_scores,
+    derive_aggregations,
+    get_source_score,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("reliability-score.server")
+
+_DASHBOARD_HTML = """<!doctype html>
+<title>Oracle Source Reliability Scores</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 2rem; color: #1a1a1a; }
+  input, button { font-size: 1rem; padding: 0.25rem 0.5rem; margin-right: 0.5rem; }
+  table { border-collapse: collapse; margin-top: 1.5rem; width: 100%; max-width: 700px; }
+  td, th { border: 1px solid #ccc; padding: 0.4rem 0.8rem; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
+</style>
+<h1>Oracle Source Reliability Scores</h1>
+<div>
+  <label>Asset <input id="asset" value="DEMO"></label>
+  <button onclick="load()">Load</button>
+</div>
+<table id="out" hidden>
+  <thead><tr><th>Source</th><th>Composite</th><th>Uptime</th><th>Freshness</th><th>Accuracy</th><th>Rounds</th></tr></thead>
+  <tbody id="rows"></tbody>
+</table>
+<p id="err" style="color:#b00"></p>
+<script>
+async function load() {
+  const asset = document.getElementById('asset').value;
+  const err = document.getElementById('err');
+  err.textContent = '';
+  const res = await fetch(`/scores?asset=${encodeURIComponent(asset)}`);
+  const body = await res.json();
+  if (!res.ok) { err.textContent = body.error || 'request failed'; document.getElementById('out').hidden = true; return; }
+  const rows = document.getElementById('rows');
+  rows.innerHTML = '';
+  for (const s of body.sort((a, b) => b.composite_score - a.composite_score)) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${s.source}</td><td>${s.composite_score.toFixed(1)}</td>` +
+      `<td>${s.uptime_score.toFixed(1)}</td><td>${s.freshness_score.toFixed(1)}</td>` +
+      `<td>${s.accuracy_score.toFixed(1)}</td><td>${s.rounds_participated}/${s.rounds_expected}</td>`;
+    rows.appendChild(tr);
+  }
+  document.getElementById('out').hidden = false;
+}
+</script>
+"""
+
+
+class ScoreState:
+    def __init__(self, scores: List[SourceReliabilityScore]):
+        self.scores = scores
+        self.scores_computed_total = len(scores)
+
+
+def _compute_state(submissions: List, weights: ScoreWeights) -> ScoreState:
+    aggregations = derive_aggregations(submissions)
+    scores = compute_scores(submissions, aggregations, weights=weights)
+    return ScoreState(scores)
+
+
+class ScoreHandler(BaseHTTPRequestHandler):
+    state: Optional[ScoreState] = None
+
+    def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        if parsed.path == "/":
+            self._respond(200, "text/html", _DASHBOARD_HTML.encode())
+        elif parsed.path == "/scores":
+            self._handle_scores(query)
+        elif parsed.path == "/score":
+            self._handle_score(query)
+        elif parsed.path == "/metrics":
+            body = f"oracle_reliability_scores_computed_total {self.state.scores_computed_total}\n"
+            self._respond(200, "text/plain", body.encode())
+        elif parsed.path == "/health":
+            self._respond(200, "application/json", b'{"status": "ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_scores(self, query) -> None:
+        asset = query.get("asset", [None])[0]
+        matching = [s for s in self.state.scores if asset is None or s.asset == asset]
+        self._respond(200, "application/json", json.dumps([asdict(s) for s in matching]).encode())
+
+    def _handle_score(self, query) -> None:
+        asset = query.get("asset", [None])[0]
+        source = query.get("source", [None])[0]
+        if not asset or not source:
+            self._respond(400, "application/json", json.dumps({"error": "asset and source are required"}).encode())
+            return
+        result = get_source_score(self.state.scores, asset, source)
+        if result is None:
+            self._respond(404, "application/json", json.dumps({"error": "no score for that asset/source"}).encode())
+            return
+        self._respond(200, "application/json", json.dumps(asdict(result)).encode())
+
+    def _respond(self, code: int, content_type: str, body: bytes) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):  # silence default request logging
+        pass
+
+
+def run_server(port: int, state: ScoreState) -> None:
+    ScoreHandler.state = state
+    log.info("reliability score endpoint + dashboard listening on :%d", port)
+    HTTPServer(("0.0.0.0", port), ScoreHandler).serve_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Oracle off-chain source reliability scoring service")
+    parser.add_argument("--events-file", help="JSONL file of event envelopes (price_submitted topic)")
+    parser.add_argument("--postgres-dsn", help="Postgres DSN to read from the oracle_events table")
+    parser.add_argument("--demo", action="store_true", help="serve against synthetic submission history")
+    parser.add_argument("--port", type=int, default=9103)
+    args = parser.parse_args()
+
+    if args.demo:
+        events = generate_submissions(
+            n_rounds=300,
+            sources=("SOURCE_A", "SOURCE_B", "SOURCE_C"),
+            noise_bps=10.0,
+            seed=1,
+            missing={"SOURCE_C": set(range(0, 300, 5))},
+            anomalies={i: {"SOURCE_B": 300.0} for i in range(0, 300, 10)},
+        )
+    elif args.postgres_dsn:
+        events = iter_from_postgres(args.postgres_dsn, topics={TOPIC_PRICE_SUBMITTED})
+    elif args.events_file:
+        events = args.events_file
+    else:
+        parser.error("one of --events-file, --postgres-dsn, or --demo is required")
+        return
+
+    submissions = list(iter_submissions(events))
+    log.info("loaded %d submission event(s)", len(submissions))
+    state = _compute_state(submissions, ScoreWeights())
+    run_server(args.port, state)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/reliability_score/test/test_scorer.py
+++ b/services/reliability_score/test/test_scorer.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from services.common.events import iter_submissions
+from services.common.synthetic import generate_submissions
+from services.reliability_score.scorer import (
+    ScoreWeights,
+    compute_scores,
+    derive_aggregations,
+    get_source_score,
+)
+
+
+def _score_synthetic(**kwargs):
+    events = generate_submissions(**kwargs)
+    submissions = list(iter_submissions(events))
+    aggregations = derive_aggregations(submissions)
+    return compute_scores(submissions, aggregations)
+
+
+def test_perfectly_reliable_source_scores_near_100_on_every_dimension():
+    scores = _score_synthetic(
+        n_rounds=100, sources=("PERFECT",), noise_bps=0.0, seed=1, interval_secs=60
+    )
+    score = get_source_score(scores, asset=scores[0].asset, source="PERFECT")
+    assert score is not None
+    assert score.uptime_score == 100.0
+    assert score.accuracy_score == 100.0
+    assert score.composite_score == 100.0
+
+
+def test_source_with_downtime_gets_proportionally_lower_uptime_score():
+    missing_rounds = set(range(0, 100, 2))  # misses exactly half the rounds
+    scores = _score_synthetic(
+        n_rounds=100,
+        sources=("FLAKY", "STABLE"),
+        noise_bps=1.0,
+        seed=2,
+        missing={"FLAKY": missing_rounds},
+    )
+    flaky = get_source_score(scores, scores[0].asset, "FLAKY")
+    stable = get_source_score(scores, scores[0].asset, "STABLE")
+
+    assert flaky.rounds_participated == 50
+    assert flaky.uptime_score == 50.0
+    assert stable.uptime_score == 100.0
+    assert flaky.composite_score < stable.composite_score
+
+
+def test_inaccurate_source_scores_lower_than_accurate_source():
+    scores = _score_synthetic(
+        n_rounds=100,
+        sources=("ACCURATE", "SLOPPY", "SLOPPY2"),
+        noise_bps=1.0,
+        seed=3,
+        anomalies={i: {"SLOPPY": 2000.0} for i in range(100)},
+    )
+    accurate = get_source_score(scores, scores[0].asset, "ACCURATE")
+    sloppy = get_source_score(scores, scores[0].asset, "SLOPPY")
+
+    assert accurate.accuracy_score > sloppy.accuracy_score
+    assert accurate.composite_score > sloppy.composite_score
+
+
+def test_slow_submitter_gets_lower_freshness_than_fast_submitter():
+    # Build submissions manually so we control lag precisely: FAST submits
+    # right at the round timestamp, SLOW submits 250s late each round.
+    from services.common.events import SubmissionEvent, AggregationEvent
+
+    submissions = []
+    aggregations = []
+    for ledger in range(1, 21):
+        ts = 1_000_000 + ledger * 60
+        submissions.append(SubmissionEvent(ledger, ts, "C", "ASSET", "FAST", 100_000))
+        submissions.append(SubmissionEvent(ledger, ts - 250, "C", "ASSET", "SLOW", 100_000))
+        aggregations.append(AggregationEvent(ledger, ts, "C", "ASSET", 100_000, 2))
+
+    scores = compute_scores(submissions, aggregations, max_lag_secs=300.0)
+    fast = get_source_score(scores, "ASSET", "FAST")
+    slow = get_source_score(scores, "ASSET", "SLOW")
+
+    assert fast.freshness_score == 100.0
+    assert slow.freshness_score < fast.freshness_score
+    assert slow.freshness_score > 0.0  # 250s lag < 300s cap, so not fully zeroed
+
+
+def test_scores_are_reproducible_for_the_same_input():
+    events = generate_submissions(n_rounds=50, sources=("A", "B", "C"), seed=99)
+    submissions = list(iter_submissions(events))
+    aggregations = derive_aggregations(submissions)
+
+    first = compute_scores(submissions, aggregations)
+    second = compute_scores(submissions, aggregations)
+    assert first == second
+
+
+def test_weights_must_sum_to_one():
+    import pytest
+
+    with pytest.raises(ValueError):
+        ScoreWeights(uptime=0.5, freshness=0.5, accuracy=0.5)
+
+
+def test_get_source_score_returns_none_for_unknown_source():
+    scores = _score_synthetic(n_rounds=10, sources=("A",), seed=4)
+    assert get_source_score(scores, scores[0].asset, "NOBODY") is None

--- a/services/reliability_score/test/test_server.py
+++ b/services/reliability_score/test/test_server.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import HTTPServer
+
+from services.common.events import iter_submissions
+from services.common.synthetic import generate_submissions
+from services.reliability_score.scorer import ScoreWeights
+from services.reliability_score.server import ScoreHandler, _compute_state
+
+
+def _start_server() -> tuple[HTTPServer, str, str]:
+    events = generate_submissions(n_rounds=50, sources=("A", "B"), seed=1)
+    asset = events[0]["data"]["asset"]
+    submissions = list(iter_submissions(events))
+    ScoreHandler.state = _compute_state(submissions, ScoreWeights())
+
+    httpd = HTTPServer(("127.0.0.1", 0), ScoreHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    port = httpd.server_address[1]
+    return httpd, f"http://127.0.0.1:{port}", asset
+
+
+def test_scores_endpoint_lists_every_source_for_the_asset():
+    httpd, base_url, asset = _start_server()
+    try:
+        with urllib.request.urlopen(f"{base_url}/scores?asset={asset}") as resp:
+            body = json.loads(resp.read())
+        assert {row["source"] for row in body} == {"A", "B"}
+    finally:
+        httpd.shutdown()
+
+
+def test_score_endpoint_returns_a_single_source_get_source_score():
+    httpd, base_url, asset = _start_server()
+    try:
+        with urllib.request.urlopen(f"{base_url}/score?asset={asset}&source=A") as resp:
+            body = json.loads(resp.read())
+        assert body["source"] == "A"
+        assert body["asset"] == asset
+        assert 0.0 <= body["composite_score"] <= 100.0
+    finally:
+        httpd.shutdown()
+
+
+def test_score_endpoint_404s_on_unknown_source():
+    httpd, base_url, asset = _start_server()
+    try:
+        try:
+            urllib.request.urlopen(f"{base_url}/score?asset={asset}&source=NOBODY")
+            assert False, "expected an HTTPError"
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 404
+    finally:
+        httpd.shutdown()
+
+
+def test_metrics_endpoint_reports_scores_computed():
+    httpd, base_url, _ = _start_server()
+    try:
+        metrics = urllib.request.urlopen(f"{base_url}/metrics").read().decode()
+        assert "oracle_reliability_scores_computed_total 2" in metrics
+    finally:
+        httpd.shutdown()
+
+
+def test_dashboard_root_serves_html():
+    httpd, base_url, _ = _start_server()
+    try:
+        with urllib.request.urlopen(base_url + "/") as resp:
+            assert b"Reliability Scores" in resp.read()
+    finally:
+        httpd.shutdown()

--- a/services/volatility_forecast/__init__.py
+++ b/services/volatility_forecast/__init__.py
@@ -1,0 +1,1 @@
+"""Off-chain short-term volatility forecasting service."""

--- a/services/volatility_forecast/forecast.py
+++ b/services/volatility_forecast/forecast.py
@@ -1,0 +1,168 @@
+"""Projects short-term price volatility from an asset's indexed aggregate
+price history, for use as risk parameters (deviation thresholds,
+circuit-breaker bounds) by consumers and the DAO.
+
+Two volatility measures are computed from the same log-return series:
+
+* **Realized volatility** — the plain historical stdev of log returns over
+  the lookback window. Backward-looking: "how volatile has this asset
+  actually been."
+* **EWMA (forward) volatility** — an exponentially-weighted variance
+  (RiskMetrics-style, decay `lambda_`) that reacts faster to a recent
+  regime change than the flat realized-vol average. This is used as the
+  forward-looking forecast basis. The oracle has no options market to
+  derive a true *implied* volatility from, so this EWMA projection is the
+  documented stand-in: it weights recent moves more heavily, the same way
+  an options market's implied vol tends to lead realized vol into a shift.
+
+The forecast projects the EWMA volatility over a horizon and reports a
+confidence window as a symmetric price band around the last observed price,
+assuming a lognormal random walk (the same assumption behind Black-Scholes-
+style vol scaling: sigma scales with sqrt(time)).
+"""
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+SECONDS_PER_YEAR = 365 * 24 * 3600
+DEFAULT_EWMA_LAMBDA = 0.94  # RiskMetrics standard decay factor
+DEFAULT_CONFIDENCE = 0.90
+
+
+def log_returns(prices: Sequence[float]) -> List[float]:
+    returns: List[float] = []
+    for prev, cur in zip(prices, prices[1:]):
+        if prev > 0 and cur > 0:
+            returns.append(math.log(cur / prev))
+    return returns
+
+
+def realized_volatility(prices: Sequence[float], interval_secs: float, annualize: bool = True) -> float:
+    """Plain historical stdev of log returns, optionally annualized."""
+    returns = log_returns(prices)
+    if len(returns) < 2:
+        return 0.0
+    period_vol = statistics.stdev(returns)
+    return _maybe_annualize(period_vol, interval_secs, annualize)
+
+
+def ewma_period_volatility(prices: Sequence[float], lambda_: float = DEFAULT_EWMA_LAMBDA) -> float:
+    """Exponentially-weighted per-period volatility (not annualized) — the
+    forward-looking forecast basis."""
+    returns = log_returns(prices)
+    if not returns:
+        return 0.0
+    variance = returns[0] ** 2
+    for r in returns[1:]:
+        variance = lambda_ * variance + (1.0 - lambda_) * r * r
+    return math.sqrt(variance)
+
+
+def ewma_volatility(
+    prices: Sequence[float], interval_secs: float, lambda_: float = DEFAULT_EWMA_LAMBDA, annualize: bool = True
+) -> float:
+    return _maybe_annualize(ewma_period_volatility(prices, lambda_), interval_secs, annualize)
+
+
+def _maybe_annualize(period_vol: float, interval_secs: float, annualize: bool) -> float:
+    if not annualize or interval_secs <= 0:
+        return period_vol
+    return period_vol * math.sqrt(SECONDS_PER_YEAR / interval_secs)
+
+
+def norm_ppf(p: float) -> float:
+    """Inverse standard normal CDF (Acklam's rational approximation, ~1e-9
+    relative error) — avoids a scipy dependency for confidence-window z-values."""
+    if not 0.0 < p < 1.0:
+        raise ValueError("p must be in (0, 1)")
+
+    a = [-3.969683028665376e01, 2.209460984245205e02, -2.759285104469687e02,
+         1.383577518672690e02, -3.066479806614716e01, 2.506628277459239e00]
+    b = [-5.447609879822406e01, 1.615858368580409e02, -1.556989798598866e02,
+         6.680131188771972e01, -1.328068155288572e01]
+    c = [-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e00,
+         -2.549732539343734e00, 4.374664141464968e00, 2.938163982698783e00]
+    d = [7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e00, 3.754408661907416e00]
+
+    p_low, p_high = 0.02425, 1 - 0.02425
+
+    if p < p_low:
+        q = math.sqrt(-2 * math.log(p))
+        return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1
+        )
+    if p <= p_high:
+        q = p - 0.5
+        r = q * q
+        return (
+            (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q
+        ) / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+
+    q = math.sqrt(-2 * math.log(1 - p))
+    return -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+        (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1
+    )
+
+
+def confidence_z(confidence: float) -> float:
+    """Two-sided z-value for a confidence level, e.g. 0.90 -> ~1.645."""
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be in (0, 1)")
+    return norm_ppf(0.5 + confidence / 2.0)
+
+
+@dataclass
+class VolatilityForecast:
+    asset: str
+    last_price: float
+    realized_volatility: float  # annualized
+    forecast_volatility: float  # annualized EWMA projection
+    horizon_secs: int
+    confidence: float
+    lower_bound: float
+    upper_bound: float
+    sample_size: int
+
+
+def forecast(
+    asset: str,
+    prices: Sequence[float],
+    interval_secs: float,
+    horizon_secs: int,
+    confidence: float = DEFAULT_CONFIDENCE,
+    lambda_: float = DEFAULT_EWMA_LAMBDA,
+) -> Optional[VolatilityForecast]:
+    """Builds a `VolatilityForecast` from a chronological price series.
+
+    Returns `None` if there isn't enough history (fewer than 3 prices) to
+    compute a meaningful volatility estimate.
+    """
+    if len(prices) < 3 or interval_secs <= 0 or horizon_secs <= 0:
+        return None
+
+    last_price = float(prices[-1])
+    realized = realized_volatility(prices, interval_secs)
+    ewma_period = ewma_period_volatility(prices, lambda_)
+    forecast_vol = _maybe_annualize(ewma_period, interval_secs, True)
+
+    n_periods = horizon_secs / interval_secs
+    sigma_horizon = ewma_period * math.sqrt(n_periods)
+    z = confidence_z(confidence)
+
+    lower = last_price * math.exp(-z * sigma_horizon)
+    upper = last_price * math.exp(z * sigma_horizon)
+
+    return VolatilityForecast(
+        asset=asset,
+        last_price=last_price,
+        realized_volatility=realized,
+        forecast_volatility=forecast_vol,
+        horizon_secs=horizon_secs,
+        confidence=confidence,
+        lower_bound=lower,
+        upper_bound=upper,
+        sample_size=len(prices),
+    )

--- a/services/volatility_forecast/requirements.txt
+++ b/services/volatility_forecast/requirements.txt
@@ -1,0 +1,5 @@
+# Off-chain volatility-forecast service dependencies.
+# Pure standard library — no hard runtime dependencies.
+
+# Optional extra (enables streaming from the oracle_events Postgres table):
+#   pip install psycopg2-binary==2.9.9

--- a/services/volatility_forecast/server.py
+++ b/services/volatility_forecast/server.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Runs the volatility-forecasting service: an HTTP endpoint returning
+realized + forecast volatility with a confidence window, plus a small
+dashboard view. See docs/volatility-forecasting.md.
+
+Usage:
+    python -m services.volatility_forecast.server --demo
+    python -m services.volatility_forecast.server --events-file events.jsonl --port 9102
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import asdict
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, List, Optional
+from urllib.parse import parse_qs, urlparse
+
+from services.common.events import EventSource, TOPIC_PRICE_AGGREGATED, iter_from_postgres, iter_aggregations
+from services.common.synthetic import generate_price_series
+from services.volatility_forecast.forecast import DEFAULT_CONFIDENCE, VolatilityForecast, forecast
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("volatility-forecast.server")
+
+_DASHBOARD_HTML = """<!doctype html>
+<title>Oracle Volatility Forecast</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 2rem; color: #1a1a1a; }
+  input, select, button { font-size: 1rem; padding: 0.25rem 0.5rem; margin-right: 0.5rem; }
+  table { border-collapse: collapse; margin-top: 1.5rem; }
+  td, th { border: 1px solid #ccc; padding: 0.4rem 0.8rem; text-align: left; }
+  .band { color: #555; }
+</style>
+<h1>Oracle Volatility Forecast</h1>
+<div>
+  <label>Asset <input id="asset" value="DEMO"></label>
+  <label>Horizon (h) <input id="horizon" type="number" value="24"></label>
+  <label>Confidence
+    <select id="confidence">
+      <option value="0.90" selected>90%</option>
+      <option value="0.95">95%</option>
+      <option value="0.99">99%</option>
+    </select>
+  </label>
+  <button onclick="load()">Forecast</button>
+</div>
+<table id="out" hidden>
+  <tr><th>Last price</th><td id="last_price"></td></tr>
+  <tr><th>Realized volatility (annualized)</th><td id="realized_volatility"></td></tr>
+  <tr><th>Forecast volatility (annualized, EWMA)</th><td id="forecast_volatility"></td></tr>
+  <tr><th>Confidence window</th><td class="band" id="band"></td></tr>
+  <tr><th>Sample size</th><td id="sample_size"></td></tr>
+</table>
+<p id="err" style="color:#b00"></p>
+<script>
+async function load() {
+  const asset = document.getElementById('asset').value;
+  const horizon = document.getElementById('horizon').value;
+  const confidence = document.getElementById('confidence').value;
+  const err = document.getElementById('err');
+  err.textContent = '';
+  const res = await fetch(`/forecast?asset=${encodeURIComponent(asset)}&horizon_hours=${horizon}&confidence=${confidence}`);
+  const body = await res.json();
+  if (!res.ok) { err.textContent = body.error || 'request failed'; document.getElementById('out').hidden = true; return; }
+  document.getElementById('last_price').textContent = body.last_price;
+  document.getElementById('realized_volatility').textContent = (body.realized_volatility * 100).toFixed(2) + '%';
+  document.getElementById('forecast_volatility').textContent = (body.forecast_volatility * 100).toFixed(2) + '%';
+  document.getElementById('band').textContent = `${body.lower_bound.toFixed(2)} – ${body.upper_bound.toFixed(2)}`;
+  document.getElementById('sample_size').textContent = body.sample_size;
+  document.getElementById('out').hidden = false;
+}
+</script>
+"""
+
+
+class ForecastState:
+    def __init__(self, price_history: Dict[str, List[float]], interval_secs: int):
+        self.price_history = price_history
+        self.interval_secs = interval_secs
+        self.forecasts_total = 0
+
+
+def load_price_history(source: EventSource) -> Dict[str, List[float]]:
+    history: Dict[str, List[float]] = {}
+    for event in iter_aggregations(source):
+        history.setdefault(event.asset, []).append(float(event.price))
+    return history
+
+
+class ForecastHandler(BaseHTTPRequestHandler):
+    state: Optional[ForecastState] = None
+
+    def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+        parsed = urlparse(self.path)
+        if parsed.path == "/":
+            self._respond(200, "text/html", _DASHBOARD_HTML.encode())
+        elif parsed.path == "/forecast":
+            self._handle_forecast(parse_qs(parsed.query))
+        elif parsed.path == "/metrics":
+            body = f"oracle_volatility_forecasts_total {self.state.forecasts_total}\n"
+            self._respond(200, "text/plain", body.encode())
+        elif parsed.path == "/health":
+            self._respond(200, "application/json", b'{"status": "ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_forecast(self, query: Dict[str, List[str]]) -> None:
+        asset = query.get("asset", [None])[0]
+        horizon_hours = float(query.get("horizon_hours", ["24"])[0])
+        confidence = float(query.get("confidence", [str(DEFAULT_CONFIDENCE)])[0])
+
+        prices = self.state.price_history.get(asset, []) if asset else []
+        if not asset or not prices:
+            self._respond(404, "application/json", json.dumps({"error": f"no history for asset {asset!r}"}).encode())
+            return
+
+        result = forecast(
+            asset,
+            prices,
+            interval_secs=self.state.interval_secs,
+            horizon_secs=int(horizon_hours * 3600),
+            confidence=confidence,
+        )
+        if result is None:
+            self._respond(422, "application/json", json.dumps({"error": "insufficient price history"}).encode())
+            return
+
+        self.state.forecasts_total += 1
+        self._respond(200, "application/json", json.dumps(asdict(result)).encode())
+
+    def _respond(self, code: int, content_type: str, body: bytes) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):  # silence default request logging
+        pass
+
+
+def run_server(port: int, state: ForecastState) -> None:
+    ForecastHandler.state = state
+    log.info("volatility forecast endpoint + dashboard listening on :%d", port)
+    HTTPServer(("0.0.0.0", port), ForecastHandler).serve_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Oracle off-chain volatility forecasting service")
+    parser.add_argument("--events-file", help="JSONL file of event envelopes (price_aggregated topic)")
+    parser.add_argument("--postgres-dsn", help="Postgres DSN to read from the oracle_events table")
+    parser.add_argument("--demo", action="store_true", help="serve against a synthetic price series")
+    parser.add_argument("--interval-secs", type=int, default=3600, help="seconds between price observations")
+    parser.add_argument("--port", type=int, default=9102)
+    args = parser.parse_args()
+
+    if args.demo:
+        events = generate_price_series(asset="DEMO", n_points=500, interval_secs=args.interval_secs, seed=42)
+    elif args.postgres_dsn:
+        events = iter_from_postgres(args.postgres_dsn, topics={TOPIC_PRICE_AGGREGATED})
+    elif args.events_file:
+        events = args.events_file
+    else:
+        parser.error("one of --events-file, --postgres-dsn, or --demo is required")
+        return
+
+    history = load_price_history(events)
+    log.info("loaded price history for %d asset(s)", len(history))
+    state = ForecastState(price_history=history, interval_secs=args.interval_secs)
+    run_server(args.port, state)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/volatility_forecast/test/test_forecast.py
+++ b/services/volatility_forecast/test/test_forecast.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from services.common.events import iter_aggregations
+from services.common.synthetic import generate_price_series
+from services.volatility_forecast.forecast import (
+    confidence_z,
+    ewma_volatility,
+    forecast,
+    log_returns,
+    norm_ppf,
+    realized_volatility,
+)
+
+
+def _prices(events):
+    return [e.price for e in iter_aggregations(events)]
+
+
+def test_log_returns_basic():
+    returns = log_returns([100.0, 110.0, 99.0])
+    assert returns == pytest.approx([math.log(1.1), math.log(99 / 110)])
+
+
+def test_realized_volatility_recovers_known_input_stdev():
+    # A hand-built series alternating +1%/-1% moves has a log-return series
+    # of exactly [+ln(1.01), -ln(1.01), ...] — an independently computable
+    # ground truth this test checks the implementation against.
+    import statistics as _statistics
+
+    prices = [100.0]
+    for i in range(20):
+        prices.append(prices[-1] * (1.01 if i % 2 == 0 else 1 / 1.01))
+    expected = _statistics.stdev([math.log(1.01) if i % 2 == 0 else -math.log(1.01) for i in range(20)])
+
+    period_vol = realized_volatility(prices, interval_secs=3600, annualize=False)
+    assert period_vol == pytest.approx(expected, rel=1e-9)
+
+
+def test_realized_volatility_scales_with_annualization():
+    prices = [100.0 * (1.001**i) for i in range(50)]
+    period = realized_volatility(prices, interval_secs=3600, annualize=False)
+    annual = realized_volatility(prices, interval_secs=3600, annualize=True)
+    periods_per_year = (365 * 24 * 3600) / 3600
+    assert annual == pytest.approx(period * math.sqrt(periods_per_year))
+
+
+def test_volatile_series_has_higher_forecast_vol_than_calm_series():
+    calm = _prices(generate_price_series(n_points=200, period_volatility=0.002, seed=1))
+    volatile = _prices(generate_price_series(n_points=200, period_volatility=0.05, seed=1))
+
+    calm_vol = ewma_volatility(calm, interval_secs=3600)
+    volatile_vol = ewma_volatility(volatile, interval_secs=3600)
+
+    assert volatile_vol > calm_vol
+
+
+def test_confidence_z_matches_known_values():
+    assert confidence_z(0.90) == pytest.approx(1.645, abs=1e-3)
+    assert confidence_z(0.95) == pytest.approx(1.960, abs=1e-3)
+    assert confidence_z(0.99) == pytest.approx(2.576, abs=1e-3)
+
+
+def test_norm_ppf_is_symmetric_around_the_median():
+    assert norm_ppf(0.5) == pytest.approx(0.0, abs=1e-9)
+    assert norm_ppf(0.25) == pytest.approx(-norm_ppf(0.75), abs=1e-9)
+
+
+def test_forecast_confidence_window_widens_with_confidence_level():
+    prices = _prices(generate_price_series(n_points=300, period_volatility=0.01, seed=5))
+    f90 = forecast("asset", prices, interval_secs=3600, horizon_secs=3600 * 24, confidence=0.90)
+    f99 = forecast("asset", prices, interval_secs=3600, horizon_secs=3600 * 24, confidence=0.99)
+
+    assert (f99.upper_bound - f99.lower_bound) > (f90.upper_bound - f90.lower_bound)
+
+
+def test_forecast_confidence_window_widens_with_horizon():
+    prices = _prices(generate_price_series(n_points=300, period_volatility=0.01, seed=6))
+    short = forecast("asset", prices, interval_secs=3600, horizon_secs=3600, confidence=0.90)
+    long = forecast("asset", prices, interval_secs=3600, horizon_secs=3600 * 24 * 7, confidence=0.90)
+
+    assert (long.upper_bound - long.lower_bound) > (short.upper_bound - short.lower_bound)
+
+
+def test_forecast_bounds_are_centered_on_the_last_price_in_log_space():
+    prices = _prices(generate_price_series(n_points=300, period_volatility=0.01, seed=7))
+    f = forecast("asset", prices, interval_secs=3600, horizon_secs=3600 * 24, confidence=0.90)
+    assert math.log(f.upper_bound / f.last_price) == pytest.approx(-math.log(f.lower_bound / f.last_price))
+
+
+def test_forecast_returns_none_with_insufficient_history():
+    assert forecast("asset", [100.0, 101.0], interval_secs=3600, horizon_secs=3600) is None
+
+
+def test_forecast_end_to_end_reports_sample_size_and_asset():
+    events = generate_price_series(n_points=100, seed=9)
+    prices = _prices(events)
+    f = forecast("MY_ASSET", prices, interval_secs=3600, horizon_secs=3600 * 6)
+    assert f.asset == "MY_ASSET"
+    assert f.sample_size == 100
+    assert f.last_price == prices[-1]
+    assert f.lower_bound < f.last_price < f.upper_bound

--- a/services/volatility_forecast/test/test_server.py
+++ b/services/volatility_forecast/test/test_server.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+from services.common.synthetic import generate_price_series
+from services.volatility_forecast.server import ForecastHandler, ForecastState, load_price_history, run_server
+from http.server import HTTPServer
+
+
+def _start_server() -> tuple[HTTPServer, str]:
+    events = generate_price_series(asset="DEMO", n_points=200, interval_secs=3600, seed=1)
+    history = load_price_history(events)
+    ForecastHandler.state = ForecastState(price_history=history, interval_secs=3600)
+
+    httpd = HTTPServer(("127.0.0.1", 0), ForecastHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    port = httpd.server_address[1]
+    return httpd, f"http://127.0.0.1:{port}"
+
+
+def test_forecast_endpoint_serves_a_valid_forecast():
+    httpd, base_url = _start_server()
+    try:
+        with urllib.request.urlopen(f"{base_url}/forecast?asset=DEMO&horizon_hours=24&confidence=0.90") as resp:
+            assert resp.status == 200
+            body = json.loads(resp.read())
+        assert body["asset"] == "DEMO"
+        assert body["lower_bound"] < body["last_price"] < body["upper_bound"]
+        assert body["sample_size"] == 200
+    finally:
+        httpd.shutdown()
+
+
+def test_forecast_endpoint_404s_on_unknown_asset():
+    httpd, base_url = _start_server()
+    try:
+        try:
+            urllib.request.urlopen(f"{base_url}/forecast?asset=NOPE")
+            assert False, "expected an HTTPError"
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 404
+    finally:
+        httpd.shutdown()
+
+
+def test_metrics_endpoint_counts_forecasts_served():
+    httpd, base_url = _start_server()
+    try:
+        urllib.request.urlopen(f"{base_url}/forecast?asset=DEMO").read()
+        urllib.request.urlopen(f"{base_url}/forecast?asset=DEMO").read()
+        metrics = urllib.request.urlopen(f"{base_url}/metrics").read().decode()
+        assert "oracle_volatility_forecasts_total 2" in metrics
+    finally:
+        httpd.shutdown()
+
+
+def test_dashboard_root_serves_html():
+    httpd, base_url = _start_server()
+    try:
+        with urllib.request.urlopen(base_url + "/") as resp:
+            assert resp.status == 200
+            assert b"Volatility Forecast" in resp.read()
+    finally:
+        httpd.shutdown()


### PR DESCRIPTION
Closes #254 
Closes #382 
Closes #383 
Closes #384 

SUMMARY
1. Explicit history pruning** — a new admin-gated `prune_history(asset, target_entries)` contract
endpoint, separate from the automatic pruning that runs on aggregation, lets operators
proactively trim an asset's oldest history entries down to a target count ahead of hitting
storage limits. Returns the number of entries pruned and emits `HistoryPrunedEvent` once per
entry removed. Covered by tests for normal pruning, no-op when already under target, pruning to
zero, admin auth, and unregistered assets.

2. Anomaly detection service** (`services/anomaly_detection/`) — an off-chain service that flags
anomalous per-source price submissions before they affect on-chain aggregation. Scores each
round with a MAD-based modified z-score (Iglewicz & Hoaglin), with an optional Isolation Forest
as a secondary temporal detector. Supports streaming, JSONL replay, and a `--demo` mode with
seeded synthetic anomalies; delivers alerts via logging or webhook and exposes `/alerts` and
`/metrics` endpoints wired into the monitoring stack.

3. Volatility forecasting service** (`services/volatility_forecast/`) — an off-chain service that
projects short-term price volatility from an asset's indexed history, computing realized
volatility (annualized stdev of log returns) and a forward-looking EWMA forecast, to inform risk
parameters such as deviation thresholds and circuit-breaker bounds. Exposes a `/forecast`
endpoint with a confidence window, a dependency-free dashboard, and `/metrics`.

4. Source reliability scoring service** (`services/reliability_score/`) — an off-chain service
that publishes a per-source reliability score combining submission uptime, freshness, and
accuracy vs. the round's aggregate price, reproducible by anyone re-running it against the same
indexed event history. Exposes `/scores` (all sources for an asset), `/score` (a single source —
the off-chain equivalent of a `get_source_score` endpoint), a dashboard, and `/metrics`.